### PR TITLE
Bump up version

### DIFF
--- a/lib/supplejack/version.rb
+++ b/lib/supplejack/version.rb
@@ -8,5 +8,5 @@
 # http://digitalnz.org/supplejack
 
 module Supplejack
-  VERSION = '1.0.5'
+  VERSION = '1.0.6'
 end

--- a/lib/supplejack/version.rb
+++ b/lib/supplejack/version.rb
@@ -8,5 +8,5 @@
 # http://digitalnz.org/supplejack
 
 module Supplejack
-  VERSION = '1.0.6'
+  VERSION = '1.0.7'
 end


### PR DESCRIPTION
Supplejack_client_dnz use the dependency from Rubygems, in order to make it use the new version of Supplejack_client; We publish the new version of Supplejack_client to RubyGems.

To use this change, we run gem build xxx-xxx; gem publish supplejack_client-x.x.x.gem
