### PR TITLE
STORIES API AUTHORISATION

### DIFF
--- a/lib/supplejack/exceptions.rb
+++ b/lib/supplejack/exceptions.rb
@@ -20,6 +20,9 @@ module Supplejack
   class StoryNotFound < StandardError
   end
 
+  class StoryUnauthorised < StandardError
+  end
+
   class MalformedRequest < StandardError
   end
 end

--- a/lib/supplejack/exceptions.rb
+++ b/lib/supplejack/exceptions.rb
@@ -8,21 +8,15 @@
 # http://digitalnz.org/supplejack
 
 module Supplejack
-  class RecordNotFound < StandardError
-  end
+  class RecordNotFound < StandardError; end
 
-  class ConceptNotFound < StandardError
-  end
+  class ConceptNotFound < StandardError; end
 
-  class SetNotFound < StandardError
-  end
+  class SetNotFound < StandardError; end
 
-  class StoryNotFound < StandardError
-  end
+  class StoryNotFound < StandardError; end
 
-  class StoryUnauthorised < StandardError
-  end
+  class StoryUnauthorised < StandardError; end
 
-  class MalformedRequest < StandardError
-  end
+  class MalformedRequest < StandardError; end
 end

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -67,9 +67,9 @@ module Supplejack
     def save
       begin
         if self.new_record?
-          self.attributes = self.class.post("/stories", { api_key: self.api_key }, { story: self.api_attributes })
+          self.attributes = self.class.post("/stories", params: { user_key: self.api_key }, payload: { story: self.api_attributes })
         else
-          self.attributes = self.class.patch("/stories/#{self.id}", params: { api_key: self.api_key }, payload: {story: self.api_attributes})
+          self.attributes = self.class.patch("/stories/#{self.id}", params: { user_key: self.api_key }, payload: {story: self.api_attributes})
         end
 
         Rails.cache.delete("/users/#{self.api_key}/stories") if Supplejack.enable_caching
@@ -91,9 +91,9 @@ module Supplejack
     #
     def destroy
       return false if self.new_record?
-      
+
       begin
-        self.class.delete("/stories/#{self.id}", { api_key: self.api_key })
+        self.class.delete("/stories/#{self.id}", { user_key: self.api_key })
 
         Rails.cache.delete("/users/#{self.api_key}/stories") if Supplejack.enable_caching
 
@@ -125,14 +125,14 @@ module Supplejack
     #
     # @return [ Story ] A Story object
     #
-    def self.find(id, api_key: nil, params: {})
-      params[:api_key] = api_key if api_key
+    def self.find(id, user_key: nil, params: {})
+      params[:user_key] = user_key if user_key
       begin
         response = get("/stories/#{id}", params)
         attributes = response || {}
 
         story = new(attributes)
-        story.api_key = api_key if api_key.present?
+        story.api_key = user_key if user_key.present?
 
         story
       rescue RestClient::ResourceNotFound

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -91,7 +91,7 @@ module Supplejack
     #
     def destroy
       return false if self.new_record?
-
+      
       begin
         self.class.delete("/stories/#{self.id}", { api_key: self.api_key })
 

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -67,9 +67,9 @@ module Supplejack
     def save
       begin
         if self.new_record?
-          self.attributes = self.class.post("/stories", {api_key: self.api_key}, {story: self.api_attributes})
+          self.attributes = self.class.post("/stories", { api_key: self.api_key }, { story: self.api_attributes })
         else
-          self.attributes = self.class.patch("/stories/#{self.id}", payload: {story: self.api_attributes})
+          self.attributes = self.class.patch("/stories/#{self.id}", params: { api_key: self.api_key }, payload: {story: self.api_attributes})
         end
 
         Rails.cache.delete("/users/#{self.api_key}/stories") if Supplejack.enable_caching
@@ -93,7 +93,7 @@ module Supplejack
       return false if self.new_record?
 
       begin
-        self.class.delete("/stories/#{self.id}")
+        self.class.delete("/stories/#{self.id}", { api_key: self.api_key })
 
         Rails.cache.delete("/users/#{self.api_key}/stories") if Supplejack.enable_caching
 

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -121,10 +121,12 @@ module Supplejack
 
     # Executes a GET request with the provided Story ID and initializes
     # a Story object with the response from the API.
+    # If api_key provided, it will be used as the api_key in the request.
     #
     # @return [ Story ] A Story object
     #
     def self.find(id, api_key: nil, params: {})
+      params[:api_key] = api_key if api_key
       begin
         response = get("/stories/#{id}", params)
         attributes = response || {}
@@ -135,6 +137,8 @@ module Supplejack
         story
       rescue RestClient::ResourceNotFound
         raise Supplejack::StoryNotFound, "Story with ID #{id} was not found"
+      rescue RestClient::Unauthorized
+        raise Supplejack::StoryUnauthorised, "Story with ID #{id} is private and requires creators api_key"
       end
     end
 

--- a/lib/supplejack/story_item_relation.rb
+++ b/lib/supplejack/story_item_relation.rb
@@ -39,7 +39,7 @@ module Supplejack
 
     def move_item(item_id, position)
       begin
-        response = post("/stories/#{story.id}/items/#{item_id}/moves", {api_key: story.api_key}, {item_id: item_id, position: position})
+        response = post("/stories/#{story.id}/items/#{item_id}/moves", { api_key: story.api_key, user_key: story.api_key}, {item_id: item_id, position: position})
 
         build_items(response)
 

--- a/spec/supplejack/story_item_relation_spec.rb
+++ b/spec/supplejack/story_item_relation_spec.rb
@@ -113,7 +113,7 @@ module Supplejack
       before do
         expect(relation).to receive(:post).with(
           "/stories/#{supplejack_story.id}/items/#{item.id}/moves",
-          {api_key: 'foobar'},
+          { api_key: 'foobar', user_key: 'foobar' },
           {item_id: 1, position: 2}
         ).and_return([
           {id: 2, type: 'embed', sub_type: 'dnz', position: 1},

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -184,7 +184,7 @@ module Supplejack
         let(:story) {Supplejack::Story.new(attributes.merge(user: user, id: '123'))}
 
         before do
-          expect(Supplejack::Story).to receive(:patch).with("/stories/123", payload: {story: attributes}) do
+          expect(Supplejack::Story).to receive(:patch).with("/stories/123", params: user, payload: {story: attributes}) do
             {
               "id" => "new-id",
               "name" => attributes[:name],
@@ -241,10 +241,10 @@ module Supplejack
     end
 
     describe '#destroy' do
-      let(:story) {Supplejack::Story.new(id: '999')}
+      let(:story) { Supplejack::Story.new(id: '999', user: { api_key: 'keysome' }) }
 
       it 'executes a delete request to the API with the user set api_key' do
-        expect(Supplejack::Story).to receive(:delete).with('/stories/999')
+        expect(Supplejack::Story).to receive(:delete).with('/stories/999', { api_key: 'keysome' })
 
         expect(story.destroy).to eq(true)
       end

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -384,7 +384,7 @@ module Supplejack
       # I've removed this functionality because I don't understand the use case
       # If we _do_ end up needing it in the future we can re add it
       it 'initializes the Story and sets the user api_key' do
-        expect(Supplejack::Story).to receive(:get).with('/stories/123abc', {}).and_return(attributes)
+        expect(Supplejack::Story).to receive(:get).with('/stories/123abc', { api_key: '98765' }).and_return(attributes)
 
         story = Supplejack::Story.find('123abc', api_key: '98765')
 

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -139,11 +139,11 @@ module Supplejack
     describe '#save' do
       context 'Story is a new_record' do
         let(:attributes) {{name: 'Story Name', description: nil, privacy: nil, copyright:nil, featured:nil, approved:nil, tags:nil, record_ids: nil}}
-        let(:user) {{api_key: 'foobar'}}
-        let(:story) {Supplejack::Story.new(attributes.merge(user: user))}
+        let(:user) {{ api_key: 'foobar' }}
+        let(:story) { Supplejack::Story.new(attributes.merge(user: user)) }
 
         before do
-          expect(Supplejack::Story).to receive(:post).with("/stories", {api_key: "foobar"}, {story: attributes}) do
+          expect(Supplejack::Story).to receive(:post).with("/stories", params: { user_key: "foobar" }, payload: { story: attributes }) do
             {
               "id" => "new-id",
               "name" => attributes[:name],
@@ -180,11 +180,11 @@ module Supplejack
 
       context 'story is not new' do
         let(:attributes) {{name: 'Story Name', description: 'desc', privacy: nil, copyright:nil, featured:nil, approved:nil, tags:nil, record_ids:nil}}
-        let(:user) {{api_key: 'foobar'}}
-        let(:story) {Supplejack::Story.new(attributes.merge(user: user, id: '123'))}
+        let(:user) { { api_key: 'foobar' } }
+        let(:story) { Supplejack::Story.new(attributes.merge(user: user, id: '123')) }
 
         before do
-          expect(Supplejack::Story).to receive(:patch).with("/stories/123", params: user, payload: {story: attributes}) do
+          expect(Supplejack::Story).to receive(:patch).with("/stories/123", params: { user_key: user[:api_key] }, payload: {story: attributes}) do
             {
               "id" => "new-id",
               "name" => attributes[:name],
@@ -195,7 +195,7 @@ module Supplejack
           end
         end
 
-        it 'triggers a PATCH request to /stories/123.json with the user set api_key' do
+        it 'triggers a PATCH request to /stories/123.json with the user set user_key' do
           story.save
         end
 
@@ -244,7 +244,7 @@ module Supplejack
       let(:story) { Supplejack::Story.new(id: '999', user: { api_key: 'keysome' }) }
 
       it 'executes a delete request to the API with the user set api_key' do
-        expect(Supplejack::Story).to receive(:delete).with('/stories/999', { api_key: 'keysome' })
+        expect(Supplejack::Story).to receive(:delete).with('/stories/999', { user_key: 'keysome' })
 
         expect(story.destroy).to eq(true)
       end
@@ -384,9 +384,9 @@ module Supplejack
       # I've removed this functionality because I don't understand the use case
       # If we _do_ end up needing it in the future we can re add it
       it 'initializes the Story and sets the user api_key' do
-        expect(Supplejack::Story).to receive(:get).with('/stories/123abc', { api_key: '98765' }).and_return(attributes)
+        expect(Supplejack::Story).to receive(:get).with('/stories/123abc', { user_key: '98765' }).and_return(attributes)
 
-        story = Supplejack::Story.find('123abc', api_key: '98765')
+        story = Supplejack::Story.find('123abc', user_key: '98765')
 
         expect(story.api_key).to eq('98765')
       end


### PR DESCRIPTION
supplejack_api has been updated to require users(creator's) api key when requesting story endpoints.

Client has to be updated to send user key on requests to Story endpoints