### PR TITLE
UPDATES TO PRIVATE STORIES PERSIST

### DIFF
--- a/lib/supplejack/user_story_relation.rb
+++ b/lib/supplejack/user_story_relation.rb
@@ -50,7 +50,7 @@ module Supplejack
     #
     def find(story_id)
       path = "/stories/#{story_id}"
-      build get(path, api_key: API_KEY)
+      build get(path, user_key: user.api_key)
     end
 
     # Initializes a new Story object and links it to the current User

--- a/spec/supplejack/user_story_relation_spec.rb
+++ b/spec/supplejack/user_story_relation_spec.rb
@@ -45,6 +45,14 @@ module Supplejack
       end
     end
 
+    describe '#find' do
+      it 'calls get method with story path and user_key' do
+        expect(relation).to receive(:get).with('/stories/th1s1sast0ry1d', { user_key: '123abc' })
+
+        relation.find('th1s1sast0ry1d')
+      end
+    end
+
     describe '#fetch' do
       context 'use_own_api_key? is false' do
         it 'fetches the users stories with the App api_key' do


### PR DESCRIPTION
Was unable to edit private stories.
This is because to find a private story user_key has to be passed to the api call.