### PR TITLE
UPDATE KERERU AND DNZ TO USE SUBJECTS

### DIFF
--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -14,7 +14,7 @@ module Supplejack
     extend ActiveModel::Naming
     include ActiveModel::Conversion
 
-    MODIFIABLE_ATTRIBUTES = [:name, :description, :privacy, :copyright, :featured, :approved, :tags, :record_ids].freeze
+    MODIFIABLE_ATTRIBUTES = [:name, :description, :privacy, :copyright, :featured, :approved, :tags, :subjects, :record_ids].freeze
     UNMODIFIABLE_ATTRIBUTES = [:id, :created_at, :updated_at, :number_of_items, :contents, :cover_thumbnail, :creator].freeze
     ATTRIBUTES = (MODIFIABLE_ATTRIBUTES + UNMODIFIABLE_ATTRIBUTES).freeze
 

--- a/lib/supplejack/user_set.rb
+++ b/lib/supplejack/user_set.rb
@@ -30,7 +30,7 @@ module Supplejack
     extend ActiveModel::Naming
 
     ATTRIBUTES = [:id, :name, :description, :privacy, :url, :priority, :count, :tags, :tag_list,
-                  :featured, :records, :created_at, :updated_at, :approved, :record]
+                  :subjects, :featured, :records, :created_at, :updated_at, :approved, :record]
     attr_accessor *ATTRIBUTES
     attr_accessor :api_key, :errors, :user
 

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -138,7 +138,7 @@ module Supplejack
 
     describe '#save' do
       context 'Story is a new_record' do
-        let(:attributes) {{name: 'Story Name', description: nil, privacy: nil, copyright:nil, featured:nil, approved:nil, tags:nil, record_ids: nil}}
+        let(:attributes) {{name: 'Story Name', description: nil, privacy: nil, copyright:nil, featured:nil, approved:nil, tags:nil, subjects: nil, record_ids: nil}}
         let(:user) {{ api_key: 'foobar' }}
         let(:story) { Supplejack::Story.new(attributes.merge(user: user)) }
 
@@ -149,6 +149,7 @@ module Supplejack
               "name" => attributes[:name],
               "description" => "",
               "tags" => [],
+              "subjects" => [],
               "contents" => []
             }
           end
@@ -179,7 +180,7 @@ module Supplejack
       end
 
       context 'story is not new' do
-        let(:attributes) {{name: 'Story Name', description: 'desc', privacy: nil, copyright:nil, featured:nil, approved:nil, tags:nil, record_ids:nil}}
+        let(:attributes) {{name: 'Story Name', description: 'desc', privacy: nil, copyright:nil, featured:nil, approved:nil, tags:nil, subjects: nil, record_ids:nil}}
         let(:user) { { api_key: 'foobar' } }
         let(:story) { Supplejack::Story.new(attributes.merge(user: user, id: '123')) }
 
@@ -190,6 +191,7 @@ module Supplejack
               "name" => attributes[:name],
               "description" => "desc",
               "tags" => [],
+              "subjects" => [],
               "contents" => []
             }
           end
@@ -357,6 +359,7 @@ module Supplejack
           featured: nil, 
           approved: nil, 
           tags: nil,
+          subjects: nil,
           contents:  nil,
           created_at: nil,
           updated_at: nil, 


### PR DESCRIPTION
Why  : SJ client needs to send and receive subjects for user_sets
What : - Added subjects to attributes
       - Updated the specs