### PR TITLE
RENAME EMBED SUBTYPE FROM DNZ TO RECORD

### DIFF
--- a/spec/supplejack/story_item_relation_spec.rb
+++ b/spec/supplejack/story_item_relation_spec.rb
@@ -17,8 +17,8 @@ module Supplejack
         user: {api_key: 'foobar'},
         name: 'test',
         contents: [
-          {id: 1, type: 'embed', sub_type: 'dnz', position: 1},
-          {id: 2, type: 'embed', sub_type: 'dnz', position: 2}
+          {id: 1, type: 'embed', sub_type: 'record', position: 1},
+          {id: 2, type: 'embed', sub_type: 'record', position: 2}
         ]
       )
     end
@@ -77,10 +77,10 @@ module Supplejack
       end
 
       it 'accepts a hash of attributes' do
-        item = relation.build(type: 'embed', sub_type: 'dnz')
+        item = relation.build(type: 'embed', sub_type: 'record')
 
         expect(item.type).to eq('embed')
-        expect(item.sub_type).to eq('dnz')
+        expect(item.sub_type).to eq('record')
       end
 
       it 'adds the Story api_key' do
@@ -116,8 +116,8 @@ module Supplejack
           { api_key: 'foobar', user_key: 'foobar' },
           {item_id: 1, position: 2}
         ).and_return([
-          {id: 2, type: 'embed', sub_type: 'dnz', position: 1},
-          {id: 1, type: 'embed', sub_type: 'dnz', position: 2}
+          {id: 2, type: 'embed', sub_type: 'record', position: 1},
+          {id: 1, type: 'embed', sub_type: 'record', position: 2}
         ])
       end
 

--- a/spec/supplejack/story_item_spec.rb
+++ b/spec/supplejack/story_item_spec.rb
@@ -14,11 +14,11 @@ module Supplejack
 
     describe '#initialize' do
       it 'accepts a hash of attributes' do
-        Supplejack::StoryItem.new(type: 'embed', sub_type: 'dnz')
+        Supplejack::StoryItem.new(type: 'embed', sub_type: 'record')
       end
 
       it 'accepts a hash with string keys' do
-        expect(Supplejack::StoryItem.new({'type' => 'embed', 'sub_type' => 'dnz'}).type).to eq('embed')
+        expect(Supplejack::StoryItem.new({'type' => 'embed', 'sub_type' => 'record'}).type).to eq('embed')
       end
 
       it 'handles nil attributes' do
@@ -33,11 +33,11 @@ module Supplejack
     end
 
     describe '#save' do
-      let(:item) { Supplejack::StoryItem.new(type: 'embed', sub_type: 'dnz', story_id: '1234', api_key: 'abc') }
+      let(:item) { Supplejack::StoryItem.new(type: 'embed', sub_type: 'record', story_id: '1234', api_key: 'abc') }
 
       context 'new item' do
         it 'triggers a POST request to create a story_item with the story api_key' do
-          expect(item).to receive(:post).with('/stories/1234/items', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'dnz'}})
+          expect(item).to receive(:post).with('/stories/1234/items', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'record'}})
 
           expect(item.save).to eq(true)
         end
@@ -46,7 +46,7 @@ module Supplejack
       context 'existing item' do
         it 'triggers a PATCH request to update a story_item with the story api_key' do
           item.id = 1
-          expect(item).to receive(:patch).with('/stories/1234/items/1', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'dnz'}})
+          expect(item).to receive(:patch).with('/stories/1234/items/1', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'record'}})
 
           expect(item.save).to eq(true)
         end


### PR DESCRIPTION
Why  : There shouldnt be any eference of dnz in opensource code base
What : Renaming dnz sub_type to record