### PR TITLE
REMOVE DNZ RELATED CODE COMMENTS FROM SUPPLEJACK

### DIFF
--- a/lib/supplejack/controllers/helpers.rb
+++ b/lib/supplejack/controllers/helpers.rb
@@ -119,7 +119,7 @@ module Supplejack
 
       # Displays the next and/or previous links based on the record and current search
       #
-      # @params [ Dnz::Record ] The record object which has information about the next/previous record and pages.
+      # @params [ Supplejack::Record ] The record object which has information about the next/previous record and pages.
       # @params [ Hash ] options Hash of options to customize the output,
       #   supported options: :prev_class, :next_class, :prev_label, :next_label
       #
@@ -175,7 +175,7 @@ module Supplejack
       # It is used in forms, so that when a user enteres another term in the search
       # box the state of the search is preserved
       #
-      # @param [ Dnz::Search ] search A instance of the Dnz::Search class
+      # @param [ Supplejack::Search ] search A instance of the Supplejack::Search class
       # @param [ Hash ] options Hash of options to remove any filter
       #
       # @option options [ Array ] except A array of fields which should not generate a hidden field
@@ -212,12 +212,12 @@ module Supplejack
         end
       end
 
-      # Returns a link with all existing search options except the specified in the params 
+      # Returns a link with all existing search options except the specified in the params
       #
       # @param [ Symbol ] name The name of the facet. Ex: :category, :subject
       # @param [ String ] value The value withing the facet. Ex: "Wellington", "Books", etc..
       # @param [ String ] path_name The name of the path used to generate the url path.
-      #   For example if you have a records_path route in your app, then specify "records" 
+      #   For example if you have a records_path route in your app, then specify "records"
       #   and it will call the records_path method
       # @param [ Hash ] options Set of options to customize the output
       # @param [ Hash ] html_options HTML options that are passed directly to the link_to method
@@ -229,13 +229,13 @@ module Supplejack
         link_text = options[:display_name].present? ? options[:display_name] : I18n.t("facets.values.#{value}", default: value)
         link_to block_given? ? capture(&block) : link_text, path.html_safe, html_options
       end
-      
+
       # Returns a link with the existing search options and adds the specified facet and value
       #
       # @param [ Symbol ] name The name of the facet. Ex: :category, :subject
       # @param [ String ] value The value withing the facet. Ex: "Wellington", "Books", etc..
       # @param [ String ] path_name The name of the path used to generate the url path.
-      #   For example if you have a records_path route in your app, then specify "records" 
+      #   For example if you have a records_path route in your app, then specify "records"
       #   and it will call the records_path method
       # @param [ Hash ] options Set of options to customize the output
       # @param [ Hash ] html_options HTML options that are passed directly to the link_to method
@@ -284,7 +284,7 @@ module Supplejack
 
       # Displays the next and/or previous links based on the record and current search
       #
-      # @params [ Dnz::Record ] The record object which has information about the next/previous record and pages.
+      # @params [ Supplejack::Record ] The record object which has information about the next/previous record and pages.
       # @params [ Hash ] options Hash of options to customize the output,
       #   supported options: :prev_class, :next_class, :prev_label, :next_label
       #
@@ -302,8 +302,8 @@ module Supplejack
 
         options = search.options
 
-        previous_label = html_options[:prev_label] ||= t('dnz_client.previous', default: "Previous")
-        next_label = html_options[:next_label] ||= t('dnz_client.next', default: "Next")
+        previous_label = html_options[:prev_label] ||= t('supplejack_client.previous', default: "Previous")
+        next_label = html_options[:next_label] ||= t('supplejack_client.next', default: "Next")
         previous_label = previous_label.html_safe
         next_label = next_label.html_safe
 
@@ -324,7 +324,7 @@ module Supplejack
         end
 
         content_tag(:span, links, class: html_options[:wrapper_class])
-      end      
+      end
 
       def generate_path(name, options={})
         segments = name.split(".")
@@ -333,7 +333,7 @@ module Supplejack
         elsif segments.size == 2
           send(segments[0]).send("#{segments[1]}_path", options)
         end
-      end 
+      end
 
     end
   end

--- a/spec/supplejack/record_spec.rb
+++ b/spec/supplejack/record_spec.rb
@@ -40,12 +40,12 @@ module Supplejack
       record = SupplejackRecord.new(nil)
       record.attributes.should eq({})
     end
-    
+
     it 'handles a string as params' do
       record = SupplejackRecord.new('')
       record.attributes.should eq({})
     end
-    
+
     it 'handles a array as params' do
       record = SupplejackRecord.new([])
       record.attributes.should eq({})
@@ -91,9 +91,9 @@ module Supplejack
       end
 
       it 'returns an array of hashes with special fields their values and schemas for multiple special_fields configured' do
-        Supplejack.stub(:special_fields) { {admin: {fields: [:location]}, dnz: {fields: [:description]}} }
+        Supplejack.stub(:special_fields) { {admin: {fields: [:location]}, user: {fields: [:description]}} }
         record = SupplejackRecord.new({:location => 'Wellington', :description => "Some description"})
-        record.metadata.should include({:name => 'location', :schema => 'admin', :value => 'Wellington'}, {:name => 'description', :schema => 'dnz', :value => 'Some description'})
+        record.metadata.should include({:name => 'location', :schema => 'admin', :value => 'Wellington'}, {:name => 'description', :schema => 'user', :value => 'Some description'})
       end
 
       it 'should not return metadata for inexistent attribtues' do
@@ -176,7 +176,7 @@ module Supplejack
           expect { SupplejackRecord.find(1) }.to raise_error(Supplejack::RecordNotFound)
         end
 
-        it 'raises a Supplejack::MalformedRequest' do 
+        it 'raises a Supplejack::MalformedRequest' do
           expect { SupplejackRecord.find('replace_this') }.to raise_error(Supplejack::MalformedRequest)
         end
 

--- a/spec/supplejack/record_spec.rb
+++ b/spec/supplejack/record_spec.rb
@@ -91,9 +91,9 @@ module Supplejack
       end
 
       it 'returns an array of hashes with special fields their values and schemas for multiple special_fields configured' do
-        Supplejack.stub(:special_fields) { {admin: {fields: [:location]}, user: {fields: [:description]}} }
+        Supplejack.stub(:special_fields) { {admin: {fields: [:location]}, supplejack_user: {fields: [:description]}} }
         record = SupplejackRecord.new({:location => 'Wellington', :description => "Some description"})
-        record.metadata.should include({:name => 'location', :schema => 'admin', :value => 'Wellington'}, {:name => 'description', :schema => 'user', :value => 'Some description'})
+        record.metadata.should include({:name => 'location', :schema => 'admin', :value => 'Wellington'}, {:name => 'description', :schema => 'supplejack_user', :value => 'Some description'})
       end
 
       it 'should not return metadata for inexistent attribtues' do

--- a/spec/supplejack/story_item_relation_spec.rb
+++ b/spec/supplejack/story_item_relation_spec.rb
@@ -17,8 +17,8 @@ module Supplejack
         user: {api_key: 'foobar'},
         name: 'test',
         contents: [
-          {id: 1, type: 'embed', sub_type: 'dnz', position: 1},
-          {id: 2, type: 'embed', sub_type: 'dnz', position: 2}
+          {id: 1, type: 'embed', sub_type: 'user', position: 1},
+          {id: 2, type: 'embed', sub_type: 'user', position: 2}
         ]
       )
     end
@@ -77,10 +77,10 @@ module Supplejack
       end
 
       it 'accepts a hash of attributes' do
-        item = relation.build(type: 'embed', sub_type: 'dnz')
+        item = relation.build(type: 'embed', sub_type: 'user')
 
         expect(item.type).to eq('embed')
-        expect(item.sub_type).to eq('dnz')
+        expect(item.sub_type).to eq('user')
       end
 
       it 'adds the Story api_key' do
@@ -116,8 +116,8 @@ module Supplejack
           { api_key: 'foobar', user_key: 'foobar' },
           {item_id: 1, position: 2}
         ).and_return([
-          {id: 2, type: 'embed', sub_type: 'dnz', position: 1},
-          {id: 1, type: 'embed', sub_type: 'dnz', position: 2}
+          {id: 2, type: 'embed', sub_type: 'user', position: 1},
+          {id: 1, type: 'embed', sub_type: 'user', position: 2}
         ])
       end
 

--- a/spec/supplejack/story_item_relation_spec.rb
+++ b/spec/supplejack/story_item_relation_spec.rb
@@ -17,8 +17,8 @@ module Supplejack
         user: {api_key: 'foobar'},
         name: 'test',
         contents: [
-          {id: 1, type: 'embed', sub_type: 'user', position: 1},
-          {id: 2, type: 'embed', sub_type: 'user', position: 2}
+          {id: 1, type: 'embed', sub_type: 'supplejack_user', position: 1},
+          {id: 2, type: 'embed', sub_type: 'supplejack_user', position: 2}
         ]
       )
     end
@@ -77,10 +77,10 @@ module Supplejack
       end
 
       it 'accepts a hash of attributes' do
-        item = relation.build(type: 'embed', sub_type: 'user')
+        item = relation.build(type: 'embed', sub_type: 'supplejack_user')
 
         expect(item.type).to eq('embed')
-        expect(item.sub_type).to eq('user')
+        expect(item.sub_type).to eq('supplejack_user')
       end
 
       it 'adds the Story api_key' do
@@ -116,8 +116,8 @@ module Supplejack
           { api_key: 'foobar', user_key: 'foobar' },
           {item_id: 1, position: 2}
         ).and_return([
-          {id: 2, type: 'embed', sub_type: 'user', position: 1},
-          {id: 1, type: 'embed', sub_type: 'user', position: 2}
+          {id: 2, type: 'embed', sub_type: 'supplejack_user', position: 1},
+          {id: 1, type: 'embed', sub_type: 'supplejack_user', position: 2}
         ])
       end
 

--- a/spec/supplejack/story_item_spec.rb
+++ b/spec/supplejack/story_item_spec.rb
@@ -14,11 +14,11 @@ module Supplejack
 
     describe '#initialize' do
       it 'accepts a hash of attributes' do
-        Supplejack::StoryItem.new(type: 'embed', sub_type: 'user')
+        Supplejack::StoryItem.new(type: 'embed', sub_type: 'supplejack_user')
       end
 
       it 'accepts a hash with string keys' do
-        expect(Supplejack::StoryItem.new({'type' => 'embed', 'sub_type' => 'user'}).type).to eq('embed')
+        expect(Supplejack::StoryItem.new({'type' => 'embed', 'sub_type' => 'supplejack_user'}).type).to eq('embed')
       end
 
       it 'handles nil attributes' do
@@ -33,11 +33,11 @@ module Supplejack
     end
 
     describe '#save' do
-      let(:item) { Supplejack::StoryItem.new(type: 'embed', sub_type: 'user', story_id: '1234', api_key: 'abc') }
+      let(:item) { Supplejack::StoryItem.new(type: 'embed', sub_type: 'supplejack_user', story_id: '1234', api_key: 'abc') }
 
       context 'new item' do
         it 'triggers a POST request to create a story_item with the story api_key' do
-          expect(item).to receive(:post).with('/stories/1234/items', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'user'}})
+          expect(item).to receive(:post).with('/stories/1234/items', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'supplejack_user'}})
 
           expect(item.save).to eq(true)
         end
@@ -46,7 +46,7 @@ module Supplejack
       context 'existing item' do
         it 'triggers a PATCH request to update a story_item with the story api_key' do
           item.id = 1
-          expect(item).to receive(:patch).with('/stories/1234/items/1', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'user'}})
+          expect(item).to receive(:patch).with('/stories/1234/items/1', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'supplejack_user'}})
 
           expect(item.save).to eq(true)
         end

--- a/spec/supplejack/story_item_spec.rb
+++ b/spec/supplejack/story_item_spec.rb
@@ -14,11 +14,11 @@ module Supplejack
 
     describe '#initialize' do
       it 'accepts a hash of attributes' do
-        Supplejack::StoryItem.new(type: 'embed', sub_type: 'dnz')
+        Supplejack::StoryItem.new(type: 'embed', sub_type: 'user')
       end
 
       it 'accepts a hash with string keys' do
-        expect(Supplejack::StoryItem.new({'type' => 'embed', 'sub_type' => 'dnz'}).type).to eq('embed')
+        expect(Supplejack::StoryItem.new({'type' => 'embed', 'sub_type' => 'user'}).type).to eq('embed')
       end
 
       it 'handles nil attributes' do
@@ -33,11 +33,11 @@ module Supplejack
     end
 
     describe '#save' do
-      let(:item) { Supplejack::StoryItem.new(type: 'embed', sub_type: 'dnz', story_id: '1234', api_key: 'abc') }
+      let(:item) { Supplejack::StoryItem.new(type: 'embed', sub_type: 'user', story_id: '1234', api_key: 'abc') }
 
       context 'new item' do
         it 'triggers a POST request to create a story_item with the story api_key' do
-          expect(item).to receive(:post).with('/stories/1234/items', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'dnz'}})
+          expect(item).to receive(:post).with('/stories/1234/items', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'user'}})
 
           expect(item.save).to eq(true)
         end
@@ -46,7 +46,7 @@ module Supplejack
       context 'existing item' do
         it 'triggers a PATCH request to update a story_item with the story api_key' do
           item.id = 1
-          expect(item).to receive(:patch).with('/stories/1234/items/1', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'dnz'}})
+          expect(item).to receive(:patch).with('/stories/1234/items/1', {user_key: 'abc'}, {item: {meta: {}, type: 'embed', sub_type: 'user'}})
 
           expect(item.save).to eq(true)
         end

--- a/spec/supplejack/user_spec.rb
+++ b/spec/supplejack/user_spec.rb
@@ -17,7 +17,7 @@ module Supplejack
     before(:each) do
       Supplejack::User.stub(:get) { {'user' => {'id' => 'abc', 'authentication_token' => '12345'}} }
     end
-    
+
     describe '#initialize' do
       it 'initializes the user attributes' do
         Supplejack::User.new({'authentication_token' => '12345'}).api_key.should eq '12345'
@@ -41,7 +41,7 @@ module Supplejack
     end
 
     describe "#sets" do
-      it "initializes a Dnz::UserSetRelation object" do
+      it "initializes a Supplejack::UserSetRelation object" do
         @relation = relation
         Supplejack::UserSetRelation.should_receive(:new).with(user) { @relation }
         user.sets.should be_a Supplejack::UserSetRelation

--- a/stories_integration_test.rb
+++ b/stories_integration_test.rb
@@ -36,7 +36,7 @@ p 'Done Update Story'
 # Create items
 p 'Create Items'
 
-assert(user.stories.first.items.create(type: 'embed', sub_type: 'dnz', content: {record_id: 123}, meta: {}), true, 'dnz embed item failed to create')
+assert(user.stories.first.items.create(type: 'embed', sub_type: 'user', content: {record_id: 123}, meta: {}), true, 'user embed item failed to create')
 assert(user.stories.first.items.create(type: 'text', sub_type: 'heading', content: {value: 'Heading'}, meta: {size: 1}), true, 'heading item failed to create')
 
 assert(user.stories.first.items.first.content[:record_id], 123, 'record_id does not match')

--- a/stories_integration_test.rb
+++ b/stories_integration_test.rb
@@ -36,7 +36,7 @@ p 'Done Update Story'
 # Create items
 p 'Create Items'
 
-assert(user.stories.first.items.create(type: 'embed', sub_type: 'user', content: {record_id: 123}, meta: {}), true, 'user embed item failed to create')
+assert(user.stories.first.items.create(type: 'embed', sub_type: 'supplejack_user', content: {record_id: 123}, meta: {}), true, 'supplejack_user embed item failed to create')
 assert(user.stories.first.items.create(type: 'text', sub_type: 'heading', content: {value: 'Heading'}, meta: {size: 1}), true, 'heading item failed to create')
 
 assert(user.stories.first.items.first.content[:record_id], 123, 'record_id does not match')


### PR DESCRIPTION
As a user of Supplejack Client, I do not want to see comments related to DNZ in the codebase, so that the open source SJ project is clean and clear.

