### PR TITLE
Remove dnz specific code from log subscriber

### DIFF
--- a/lib/supplejack/log_subscriber.rb
+++ b/lib/supplejack/log_subscriber.rb
@@ -14,13 +14,13 @@ module Supplejack
     # FIXME: make line 24 (request = "") shorter
     def log_request(duration, payload, solr_request_params={})
       return unless Supplejack.enable_debugging
-      
+
       solr_request_params ||= {}
       payload ||= {}
       payload.reverse_merge!({:params => {}, :options => {}, :payload => {}})
       method = payload[:method] || :get
-      
-      name = '%s (%.1fms)' % ["Supplejack API #{api_environment}", duration]
+
+      name = '%s (%.1fms)' % ["Supplejack API #{Rails.env}", duration]
 
       parameters = payload[:params].map { |k, v| "#{k}: #{colorize(v, BOLD)}" }.join(', ')
       body = payload[:payload].map { |k, v| "#{k}: #{colorize(v, BOLD)}" }.join(', ')
@@ -39,7 +39,7 @@ module Supplejack
 
       debug "  #{colorize(name, GREEN)}  [ #{request} ] #{info}"
     end
-    
+
     def colorize(text, color)
       if text.is_a?(Hash)
         "{#{text.map {|k, v| "#{k}: #{colorize(v, color)}" }.join(', ')}}"
@@ -49,14 +49,6 @@ module Supplejack
         "#{BOLD}#{color}#{text}#{CLEAR}"
       end
     end
-    
-    def api_environment
-      case Supplejack.api_url
-      when "http://api.digitalnz.org" then "Prod"
-      when /(hippo.uat)|(api.uat)/ then "Staging"
-      else
-        "Dev"
-      end
-    end
+
   end
 end

--- a/spec/supplejack/log_subscriber_spec.rb
+++ b/spec/supplejack/log_subscriber_spec.rb
@@ -11,32 +11,12 @@ require 'spec_helper'
 
 module Supplejack
   describe LogSubscriber do
-    
+
     it 'returns nil when logging not enabled' do
       Supplejack.stub(:enable_logging) { false }
+
       Supplejack::LogSubscriber.new.log_request(1, {}).should be_nil
     end
-    
-    describe '#api_environment' do
-      it 'returns Prod' do
-        Supplejack.stub(:api_url) { 'http://api.digitalnz.org' }
-        Supplejack::LogSubscriber.new.api_environment.should eq 'Prod'
-      end
-      
-      it 'returns Staging' do
-        Supplejack.stub(:api_url) { 'http://hippo.uat.digitalnz.org:8001' }
-        Supplejack::LogSubscriber.new.api_environment.should eq 'Staging'
-      end
-      
-      it 'returns Staging' do
-        Supplejack.stub(:api_url) { 'http://api.uat.digitalnz.org' }
-        Supplejack::LogSubscriber.new.api_environment.should eq 'Staging'
-      end
-      
-      it 'returns Dev' do
-        Supplejack.stub(:api_url) { 'http://localhost:3000' }
-        Supplejack::LogSubscriber.new.api_environment.should eq 'Dev'
-      end
-    end
+
   end
 end


### PR DESCRIPTION
This pr removes dnz specific code from the log subscriber, specifically, the environment check was checking the dnz api url. 