### PR TITLE
Gm/moderation table

### DIFF
--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -207,22 +207,12 @@ module Supplejack
     # Executes a GET request to the API /stories/moderations endpoint to retrieve
     # all public UserSet objects.
     #
-    # @param [ Hash ] options Supported options: :page, :per_page
-    #
-    # @option options [ Integer ] :page The page number used to paginate through the UserSet objects
-    # @option options [ Integer ] :per_page The per_page number to select the number of UserSet objects per page.
-    #
     # @return [ Array ] A array of Supplejack::UserSet objects
-    #
-    def self.moderation(options = {})
-      options.reverse_merge!(page: 1, per_page: 100)
-      response = get('/stories/moderation', options)
+
+    def self.all_public_stories(options = {})
+      response = get('/stories/moderations', options)
       sets_array = response['sets'] || []
-      user_sets = sets_array.map {|attrs| new(attrs) }
-      Supplejack::PaginatedCollection.new(user_sets,
-                                          options[:page].to_i,
-                                          options[:per_page].to_i,
-                                          response['total'].to_i)
+      sets_array.map { |attrs| new(attrs) }
     end
 
     # Compares the api_key of the user and the api_key assigned to the Story

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -15,7 +15,7 @@ module Supplejack
     include ActiveModel::Conversion
 
     MODIFIABLE_ATTRIBUTES = [:name, :description, :privacy, :copyright, :featured, :approved, :tags, :subjects, :record_ids, :count, :featured_at].freeze
-    UNMODIFIABLE_ATTRIBUTES = [:id, :created_at, :updated_at, :number_of_items, :contents, :cover_thumbnail, :creator].freeze
+    UNMODIFIABLE_ATTRIBUTES = [:id, :created_at, :updated_at, :number_of_items, :contents, :cover_thumbnail, :creator, :user_id].freeze
     ATTRIBUTES = (MODIFIABLE_ATTRIBUTES + UNMODIFIABLE_ATTRIBUTES).freeze
 
     attr_accessor *ATTRIBUTES

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -385,7 +385,8 @@ module Supplejack
           record_ids: nil,
           cover_thumbnail: nil,
           creator: 'Wilfred',
-          count: nil
+          count: nil,
+          user_id: nil
        }
       end
 

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -349,6 +349,21 @@ module Supplejack
       end
     end
 
+    describe '#all_public_stories' do
+      let(:api_key) { '123456' }
+      it "returns an array with all stories from /stories/moderations endpoint" do
+
+        expect(Supplejack::Story).to receive(:get).and_return({
+          'sets' => [
+            Supplejack::User.new(api_key: api_key).attributes,
+            Supplejack::User.new(api_key: api_key).attributes
+          ]
+        })
+
+        expect(Supplejack::Story.all_public_stories.count).to eq(2)
+      end
+    end
+
     describe '#find' do
       let(:attributes) do
         {


### PR DESCRIPTION
Acceptance Criteria
=================
- admin can search for stories
- admin can find/sort for stories that are different sizes

Background
=================
As a digitalnz.org admin I want to be able to search for and sort stories in moderation so that I can find particular stories and story types easily

- Change API endpoint to return all stories that are public without pagination to be consumed by the datatable js.

Checklist
=================

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Builds Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)