### PR TITLE
RAISE TIMEOUT ERROR ON SEARCH

### DIFF
--- a/lib/supplejack/exceptions.rb
+++ b/lib/supplejack/exceptions.rb
@@ -11,4 +11,8 @@ module Supplejack
   class StoryUnauthorised < StandardError; end
 
   class MalformedRequest < StandardError; end
+
+  class RequestTimeout < StandardError; end
+
+  class ApiNotAvailable < StandardError; end  
 end

--- a/lib/supplejack/request.rb
+++ b/lib/supplejack/request.rb
@@ -87,8 +87,11 @@ module Supplejack
       Supplejack.api_url + path + ".#{format.to_s}" + '?' + params.to_query
     end
 
+    # Found ou that RestClient timeouts are not reliable. Setting a 30 sec 
+    # timeout is taking about 60 seconds re raise timeout error. So now the
+    # default value is 15 
     def timeout(options={})
-      timeout = Supplejack.timeout.to_i == 0 ? 30 : Supplejack.timeout.to_i
+      timeout = Supplejack.timeout.to_i == 0 ? 15 : Supplejack.timeout.to_i
       options[:timeout] || timeout
     end
 

--- a/lib/supplejack/request.rb
+++ b/lib/supplejack/request.rb
@@ -15,7 +15,7 @@ module Supplejack
       payload = {:path => path, :params => params, :options => options}
 
       begin
-        result = RestClient::Request.execute(:url => url, :method => :get, :timeout => timeout(options))
+        result = RestClient::Request.execute(:url => url, :method => :get, :read_timeout => timeout(options))
         result = JSON.parse(result) if result
       rescue RestClient::ServiceUnavailable => e
         retry unless (tries -= 1).zero?
@@ -25,7 +25,7 @@ module Supplejack
         raise e
       ensure
         duration = (Time.now - started)*1000 # Convert to miliseconds
-        solr_request_params = result["search"]['solr_request_params'] if result && result.is_a?(Hash) && result['search']
+        solr_request_params = result['search']['solr_request_params'] if result && result.is_a?(Hash) && result['search']
         @subscriber = Supplejack::LogSubscriber.new
         @subscriber.log_request(duration, payload, solr_request_params)
       end

--- a/lib/supplejack/search.rb
+++ b/lib/supplejack/search.rb
@@ -299,8 +299,10 @@ module Supplejack
         else
           @response = get(request_path, @api_params)
         end
-      rescue RestClient::ServiceUnavailable, RestClient::Exceptions::ReadTimeout => e
-        raise e
+      rescue RestClient::ServiceUnavailable => e
+        raise Supplejack::ApiNotAvailable, 'API is not responding'
+      rescue RestClient::RequestTimeout, RestClient::Exceptions::ReadTimeout => e
+        raise Supplejack::RequestTimeout, 'API call has timedout'
       rescue StandardError => e
         @response = {'search' => {}}
       end

--- a/lib/supplejack/search.rb
+++ b/lib/supplejack/search.rb
@@ -299,14 +299,15 @@ module Supplejack
         else
           @response = get(request_path, @api_params)
         end
+      rescue RestClient::ServiceUnavailable, RestClient::Exceptions::ReadTimeout => e
+        raise e
       rescue StandardError => e
         @response = {'search' => {}}
       end
     end
 
     def cacheable?
-      return false if text.present? || page > 1
-      return true
+      !(text.present? || page > 1)
     end
 
     # Gets the category facet unrestricted by the current category filter

--- a/spec/supplejack/request_spec.rb
+++ b/spec/supplejack/request_spec.rb
@@ -19,7 +19,7 @@ module Supplejack
       end
 
       it 'serializes the parameters in the url' do
-        RestClient::Request.should_receive(:execute).with(hash_including(:url => "http://api.org/records.json?#{{:and => {:name => 'John'}}.to_query}&api_key=123"))
+        RestClient::Request.should_receive(:execute).with(url: "http://api.org/records.json?#{{ and: { name: 'John' } }.to_query}&api_key=123", method: :get, read_timeout: 20)
         @test.get('/records', {:and => {:name => 'John'}})
       end
 

--- a/spec/supplejack/request_spec.rb
+++ b/spec/supplejack/request_spec.rb
@@ -155,16 +155,17 @@ module Supplejack
 
     describe '#timeout' do
       it 'defaults to the timeout in the configuration' do
-        @test.send(:timeout).should eq 20
+        expect(@test.send(:timeout)).to eq 20
       end
 
       it 'defaults to 30 when not set in the configuration' do
         Supplejack.stub(:timeout) { nil }
-        @test.send(:timeout).should eq 30
+
+        expect(@test.send(:timeout)).to eq 15
       end
 
       it 'overrides the timeout' do
-        @test.send(:timeout, {:timeout => 60}).should eq 60
+        expect(@test.send(:timeout, {timeout: 60})).to eq 60
       end
     end
 
@@ -194,6 +195,5 @@ module Supplejack
         @test.send(:full_url, '/records', nil, nil).should eq 'http://api.org/records.json?api_key=123'
       end
     end
-
   end
 end

--- a/spec/supplejack/search_spec.rb
+++ b/spec/supplejack/search_spec.rb
@@ -447,6 +447,28 @@ module Supplejack
         @search.execute_request.should eq({'search' => {}})
       end
 
+
+      context 'error handling' do
+        it 'raises a timeout error' do
+          allow(@search).to receive(:get).and_raise(RestClient::Exceptions::ReadTimeout)
+
+          expect { @search.execute_request }.to raise_error(RestClient::Exceptions::ReadTimeout)
+        end
+
+        it 'raises a unavailable error' do
+          allow(@search).to receive(:get).and_raise(RestClient::ServiceUnavailable)
+
+          expect { @search.execute_request }.to raise_error(RestClient::ServiceUnavailable)
+        end        
+
+        it 'raises no error but returns an empty search' do
+          allow(@search).to receive(:get).and_raise(StandardError)
+
+          expect(@search.execute_request).to eq ({'search'=>{}})
+        end
+
+      end
+
       context 'caching enabled' do
         before :each do
           @cache = double(:cache).as_null_object

--- a/spec/supplejack/search_spec.rb
+++ b/spec/supplejack/search_spec.rb
@@ -452,13 +452,13 @@ module Supplejack
         it 'raises a timeout error' do
           allow(@search).to receive(:get).and_raise(RestClient::Exceptions::ReadTimeout)
 
-          expect { @search.execute_request }.to raise_error(RestClient::Exceptions::ReadTimeout)
+          expect { @search.execute_request }.to raise_error(Supplejack::RequestTimeout)
         end
 
         it 'raises a unavailable error' do
           allow(@search).to receive(:get).and_raise(RestClient::ServiceUnavailable)
 
-          expect { @search.execute_request }.to raise_error(RestClient::ServiceUnavailable)
+          expect { @search.execute_request }.to raise_error(Supplejack::ApiNotAvailable)
         end        
 
         it 'raises no error but returns an empty search' do


### PR DESCRIPTION
Why  : SJ Client users require a timeout error to be raised and not blank result
What : Updated the get method Request module to use read_timeout instead of timeout
       Raising a restclient timeout and service unavailable error on execute_request in Search class

- [ ] [ ] Pull Request should have a descriptive title
- [ ] [ ] Code is understandable without Dev
- [ ] [ ] Acceptance criteria:  As a user of Supplejack Client, I would like requests that take longer than the timeout length that I have specified to raise an exception, so that I can handle it accordingly in my application.
- [ ] [ ] All new methods have a relevant spec