### PR TITLE
LAZY LOADING OF MODERATION DASHBOARD

### DIFF
--- a/lib/supplejack/controllers/helpers.rb
+++ b/lib/supplejack/controllers/helpers.rb
@@ -120,6 +120,7 @@ module Supplejack
       # @option options [ String ] :wrapper_class The CSS class to use on the wrapping span
       # @option options [ String ] :prev_label Any HTML to be put inside the previous button
       # @option options [ String ] :next_label Any HTML to be put inside the next button
+      # @option options [ String ] :include_querystring Includes the query string in the button links
       #
       def next_previous_links(record, html_options = {})
         html_options.reverse_merge!(prev_class: 'prev', next_class: 'next', wrapper_class: 'nav', prev_label: nil, next_label: nil)
@@ -142,7 +143,9 @@ module Supplejack
 
         if record.previous_record
           options[:page] = record.previous_page if record.previous_page.to_i > 1
-          links += link_to(raw(previous_label), link_to_record(record_path(record.previous_record, search: options)), class: html_options[:prev_class]).html_safe
+          path = record_path(record.previous_record, search: options)
+          path = "#{path}?#{request.query_string}" if html_options[:include_querystring]
+          links += link_to(raw(previous_label), path, class: html_options[:prev_class]).html_safe
         else
           links += content_tag(:span, previous_label, class: html_options[:prev_class])
         end
@@ -155,7 +158,9 @@ module Supplejack
 
         if record.next_record
           options[:page] = record.next_page if record.next_page.to_i > 1
-          links += link_to(raw(next_label), link_to_record(record_path(record.next_record, search: options)), class: html_options[:next_class]).html_safe
+          path = record_path(record.next_record, search: options)
+          path = "#{path}?#{request.query_string}" if html_options[:include_querystring]
+          links += link_to(raw(next_label), path, class: html_options[:next_class]).html_safe
         else
           links += content_tag(:span, next_label, class: html_options[:next_class])
         end

--- a/lib/supplejack/controllers/helpers.rb
+++ b/lib/supplejack/controllers/helpers.rb
@@ -144,6 +144,7 @@ module Supplejack
         if record.previous_record
           options[:page] = record.previous_page if record.previous_page.to_i > 1
           path = record_path(record.previous_record, search: options)
+          path = path.split('?')[0] if path.include?('?') && html_options[:include_querystring]
           path = "#{path}?#{request.query_string}" if html_options[:include_querystring]
           links += link_to(raw(previous_label), path, class: html_options[:prev_class]).html_safe
         else
@@ -159,6 +160,7 @@ module Supplejack
         if record.next_record
           options[:page] = record.next_page if record.next_page.to_i > 1
           path = record_path(record.next_record, search: options)
+          path = path.split('?')[0] if path.include?('?') && html_options[:include_querystring]
           path = "#{path}?#{request.query_string}" if html_options[:include_querystring]
           links += link_to(raw(next_label), path, class: html_options[:next_class]).html_safe
         else

--- a/lib/supplejack/controllers/helpers.rb
+++ b/lib/supplejack/controllers/helpers.rb
@@ -127,31 +127,39 @@ module Supplejack
         return '' unless params[:search]
 
         links = ''.html_safe
-
         options = search.options
-
-        previous_label = html_options[:prev_label] ||= t('supplejack_client.previous', default: 'Previous')
-        next_label = html_options[:next_label] ||= t('supplejack_client.next', default: 'Next')
-        previous_label = previous_label.html_safe
-        next_label = next_label.html_safe
-
         options[:path] = params[:search][:path].gsub(/(\W|\d)/, '') if params[:search] && params[:search][:path]
+
+        links = previous_record_link(links, record, options, html_options)
+        links = next_record_link(links, record, options, html_options)
+
+        content_tag(:span, links, class: html_options[:wrapper_class])
+      end
+
+      def previous_record_link(links, record, options, html_options)
+        previous_label = html_options[:prev_label] ||= t('supplejack_client.previous', default: 'Previous')
+        previous_label = previous_label.html_safe
 
         if record.previous_record
           options[:page] = record.previous_page if record.previous_page.to_i > 1
-          links += link_to(raw(previous_label), record_path(record.previous_record, search: options), class: html_options[:prev_class]).html_safe
+          links += link_to(raw(previous_label), link_to_record(record_path(record.previous_record, search: options)), class: html_options[:prev_class]).html_safe
         else
           links += content_tag(:span, previous_label, class: html_options[:prev_class])
         end
+        links
+      end
+
+      def next_record_link(links, record, options, html_options)
+        next_label = html_options[:next_label] ||= t('supplejack_client.next', default: 'Next')
+        next_label = next_label.html_safe
 
         if record.next_record
           options[:page] = record.next_page if record.next_page.to_i > 1
-          links += link_to(raw(next_label), record_path(record.next_record, search: options), class: html_options[:next_class]).html_safe
+          links += link_to(raw(next_label), link_to_record(record_path(record.next_record, search: options)), class: html_options[:next_class]).html_safe
         else
           links += content_tag(:span, next_label, class: html_options[:next_class])
         end
-
-        content_tag(:span, links, class: html_options[:wrapper_class])
+        links
       end
 
       def attribute_link_replacement(value, link_pattern)
@@ -277,51 +285,6 @@ module Supplejack
         end
         url = url + '?' + { search: search_options }.to_query if search_options.try(:any?)
         link_to(name, url, html_options)
-      end
-
-      # Displays the next and/or previous links based on the record and current search
-      #
-      # @params [ Supplejack::Record ] The record object which has information about the next/previous record and pages.
-      # @params [ Hash ] options Hash of options to customize the output,
-      #   supported options: :prev_class, :next_class, :prev_label, :next_label
-      #
-      # @option options [ String ] :prev_class The CSS class to use on the previous button
-      # @option options [ String ] :next_class The CSS class to use on the next button
-      # @option options [ String ] :wrapper_class The CSS class to use on the wrapping span
-      # @option options [ String ] :prev_label Any HTML to be put inside the previous button
-      # @option options [ String ] :next_label Any HTML to be put inside the next button
-      #
-      def next_previous_links(record, html_options = {})
-        html_options.reverse_merge!(prev_class: 'prev', next_class: 'next', wrapper_class: 'nav', prev_label: nil, next_label: nil)
-
-        return '' unless params[:search]
-
-        links = ''.html_safe
-
-        options = search.options
-
-        previous_label = html_options[:prev_label] ||= t('supplejack_client.previous', default: 'Previous')
-        next_label = html_options[:next_label] ||= t('supplejack_client.next', default: 'Next')
-        previous_label = previous_label.html_safe
-        next_label = next_label.html_safe
-
-        options[:path] = params[:search][:path].gsub(/(\W|\d)/, '') if params[:search] && params[:search][:path]
-
-        if record.previous_record
-          options[:page] = record.previous_page if record.previous_page.to_i > 1
-          links += link_to(raw(previous_label), record_path(record.previous_record, search: options), class: html_options[:prev_class]).html_safe
-        else
-          links += content_tag(:span, previous_label, class: html_options[:prev_class])
-        end
-
-        if record.next_record
-          options[:page] = record.next_page if record.next_page.to_i > 1
-          links += link_to(raw(next_label), record_path(record.next_record, search: options), class: html_options[:next_class]).html_safe
-        else
-          links += content_tag(:span, next_label, class: html_options[:next_class])
-        end
-
-        content_tag(:span, links, class: html_options[:wrapper_class])
       end
 
       def generate_path(name, options = {})

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -204,8 +204,8 @@ module Supplejack
 
     def self.all_public_stories(options = {})
       response = get('/stories/moderations', options)
-      sets_array = response['sets'] || []
-      sets_array.map { |attrs| new(attrs) }
+      response['sets'].map! { |attrs| new(attrs) } || []
+      options[:meta_included] ? response : response['sets']
     end
 
     # Compares the api_key of the user and the api_key assigned to the Story

--- a/spec/supplejack/controllers/helpers_spec.rb
+++ b/spec/supplejack/controllers/helpers_spec.rb
@@ -265,6 +265,26 @@ module Supplejack
           @c.attribute_link_replacement('Images', '/records?i[category]=%7B%7Bvalue%7D%7D').should eq(@c.link_to('Images', '/records?i[category]=Images'))
         end
       end
+
+      describe '#next_previous_links' do
+        before(:each) do
+          @previous_record = mock_record(record_id: 1234)
+          @next_record = mock_record(record_id: 5678)
+          @record = mock_record(record_id: 1_234_567, previous_record: @previous_record, next_record: @next_record)
+          @c.stub(:params) { { search: { text: 'cat' } } }
+        end
+
+        it 'returns empty when there is no search query' do
+          @c.stub(:params) { {} }
+          @c.next_previous_links(@record).should eq ''
+        end
+
+        it 'displays the next and previous links' do
+          @c.stub(:previous_record_link) { '<a class="prev" href="/records/37674826?search%5Bpath%5D=items&amp;search%5Btext%5D=Forest+fire">Previous result</a>' }
+          @c.stub(:next_record_link) { '<a class="next" href="/records/37674826?search%5Bpath%5D=items&amp;search%5Btext%5D=Forest+fire">Next result</a>' }
+          @c.next_previous_links(@record).should eq %(<span class=\"nav\">&lt;a class=&quot;next&quot; href=&quot;/records/37674826?search%5Bpath%5D=items&amp;amp;search%5Btext%5D=Forest+fire&quot;&gt;Next result&lt;/a&gt;</span>)
+        end
+      end
     end
   end
 end

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -355,6 +355,20 @@ module Supplejack
 
         expect(Supplejack::Story.all_public_stories.count).to eq(2)
       end
+
+      it 'includes stories metadata if :meta_included option passed' do
+        expect(Supplejack::Story).to receive(:get).and_return(
+          'sets' => [
+            Supplejack::User.new(api_key: api_key).attributes,
+            Supplejack::User.new(api_key: api_key).attributes
+          ],
+          'per_page' => 10,
+          'page' => 1,
+          'total' => 2,
+          'total_filtered' => 2
+        )
+        expect(Supplejack::Story.all_public_stories(meta_included: true)).to include('sets', 'total_filtered', 'total', 'page', 'per_page')
+      end
     end
 
     describe '#find' do


### PR DESCRIPTION
### Acceptance Criteria
- Only the records required on a given page are loaded
- Moderation dashboard page load time is reduced
- All current functionality still works.

**Notes**
Use new API moderation endpoints for pagination, search and sorting -> https://www.pivotaltracker.com/story/show/165405731
The new endpoint has been implemented on the API, the changes are on the `pm/moderation` branch

An example can be found here:
https://datatables.net/examples/server_side/object_data.html