### PR TITLE
Utilize per_page params from Search

### DIFF
--- a/lib/supplejack/search.rb
+++ b/lib/supplejack/search.rb
@@ -223,19 +223,10 @@ module Supplejack
       params[:text] = url_format.text
       params[:text] = text if text.present?
       params[:geo_bbox] = geo_bbox if geo_bbox.present?
+      params[:per_page] = per_page if per_page.present?
       params[:query_fields] = url_format.query_fields
       params = merge_extra_filters(params)
       params
-    end
-
-    # Gets the type facet unrestricted by the current type filter
-    #
-    # @return [Hash{String => Integer}] A hash of type names and counts
-    #
-    def categories(options = {})
-      return @categories if @categories
-
-      @categories = facet_values('category', options)
     end
 
     # Gets the facet values unrestricted by the current filter

--- a/spec/supplejack/search_spec.rb
+++ b/spec/supplejack/search_spec.rb
@@ -435,6 +435,11 @@ module Supplejack
           expected_filters = { photos: { has_large_thumbnail_url: 'Y', '-category'.to_sym => 'Groups' } }
           @search.counts_params(query_parameters).should include(facet_query: expected_filters)
         end
+
+        it 'adds per_page params if present' do
+          @search = Search.new(per_page: 0)
+          @search.counts_params({}).should include(per_page: 0)
+        end
       end
     end
 


### PR DESCRIPTION
This allows us to use the `per_page` params defined in the `Search` instance when calling `counts` method.