### PR TITLE
SPECIAL STORY ATTRIBUTES

### DIFF
--- a/lib/generators/templates/supplejack_client.rb
+++ b/lib/generators/templates/supplejack_client.rb
@@ -45,6 +45,14 @@ Supplejack.configure do |config|
     :default
   ]
 
+  # ===> Special story attributes
+  # This is a list of fields that the Story API / Story moderation API
+  # can return if extra fields are added to StoriesModerationSerializer of the API.
+  #
+  # config.special_story_attributes = [
+  #   :copyright_auto_checked
+  # ]
+
   # ===> Number of facet values
   # This will limit the number of facet values returned for each facet
   # Be carefull not to make it too high for performance reasons

--- a/lib/supplejack/config.rb
+++ b/lib/supplejack/config.rb
@@ -14,64 +14,60 @@ module Supplejack
     #   etc....
     # end
 
-    API_KEY                   = nil
-    API_URL                   = 'http://api.digitalnz.org'
-    URL_FORMAT                = :item_hash
-    FACETS                    = [].freeze
-    FACETS_PIVOTS             = [].freeze
-    FACETS_PER_PAGE           = 10
-    FACETS_SORT               = nil
-    PER_PAGE                  = 20
-    PAGINATION_LIMIT          = nil
-    TIMEOUT                   = 30
-    RECORD_KLASS              = 'Record'
-    CURRENT_USER_METHOD       = :current_user
-    SEARCH_KLASS              = nil
-    FIELDS                    = [:default].freeze
-    SUPPLEJACK_FIELDS         = [].freeze
-    SPECIAL_FIELDS            = [].freeze
-    ENABLE_DEBUGGING          = false
-    ENABLE_CACHING            = false
-    ATTRIBUTE_TAG             = :p
-    LABEL_TAG                 = :strong
-    LABEL_CLASS               = nil
-    STICKY_FACETS             = false
-    NON_TEXT_FIELDS           = [].freeze
+    API_KEY                  = nil
+    API_URL                  = 'http://api.digitalnz.org'
+    ATTRIBUTE_TAG            = :p
+    CURRENT_USER_METHOD      = :current_user
+    ENABLE_DEBUGGING         = false
+    ENABLE_CACHING           = false
+    FACETS                   = [].freeze
+    FACETS_PIVOTS            = [].freeze
+    FACETS_PER_PAGE          = 10
+    FACETS_SORT              = nil
+    FIELDS                   = [:default].freeze
+    LABEL_TAG                = :strong
+    LABEL_CLASS              = nil
+    NON_TEXT_FIELDS          = [].freeze
+    PER_PAGE                 = 20
+    PAGINATION_LIMIT         = nil
+    RECORD_KLASS             = 'Record'
+    SEARCH_KLASS             = nil
+    SEARCH_ATTRIBUTES        = %i[location].freeze
+    SINGLE_VALUE_METHODS     = %i[description].freeze
+    STICKY_FACETS            = false
+    SPECIAL_STORY_ATTRIBUTES = [].freeze
+    SPECIAL_FIELDS           = [].freeze
+    SUPPLEJACK_FIELDS        = [].freeze
+    TIMEOUT                  = 30
+    URL_FORMAT               = :item_hash
 
     VALID_OPTIONS_KEYS = %i[
       api_key
       api_url
+      attribute_tag
+      current_user_method
+      enable_debugging
+      enable_caching
       facet_pivots
       facets
       facets_per_page
       facets_sort
-      single_value_methods
-      search_attributes
-      url_format
-      per_page
-      pagination_limit
-      timeout
-      record_klass
-      current_user_method
-      search_klass
       fields
-      supplejack_fields
-      special_fields
-      enable_debugging
-      enable_caching
-      attribute_tag
       label_tag
       label_class
-      sticky_facets
       non_text_fields
-    ].freeze
-
-    SINGLE_VALUE_METHODS = [
-      :description
-    ].freeze
-
-    SEARCH_ATTRIBUTES = [
-      :location
+      per_page
+      pagination_limit
+      record_klass
+      search_attributes
+      search_klass
+      single_value_methods
+      special_fields
+      special_story_attributes
+      sticky_facets
+      supplejack_fields
+      timeout
+      url_format
     ].freeze
 
     attr_accessor *VALID_OPTIONS_KEYS
@@ -93,29 +89,31 @@ module Supplejack
     def reset
       self.api_key                  = API_KEY
       self.api_url                  = API_URL
+      self.attribute_tag            = ATTRIBUTE_TAG
+      self.current_user_method      = CURRENT_USER_METHOD
+      self.enable_debugging         = ENABLE_DEBUGGING
+      self.enable_caching           = ENABLE_CACHING
       self.facets                   = FACETS
       self.facet_pivots             = FACETS_PIVOTS
       self.facets_per_page          = FACETS_PER_PAGE
       self.facets_sort              = FACETS_SORT
-      self.sticky_facets            = STICKY_FACETS
-      self.single_value_methods     = SINGLE_VALUE_METHODS
-      self.search_attributes        = SEARCH_ATTRIBUTES
-      self.url_format               = URL_FORMAT
-      self.per_page                 = PER_PAGE
-      self.pagination_limit         = PAGINATION_LIMIT
-      self.timeout                  = TIMEOUT
-      self.record_klass             = RECORD_KLASS
-      self.current_user_method      = CURRENT_USER_METHOD
-      self.search_klass             = SEARCH_KLASS
       self.fields                   = FIELDS
-      self.supplejack_fields        = SUPPLEJACK_FIELDS
-      self.special_fields           = SPECIAL_FIELDS
-      self.enable_debugging         = ENABLE_DEBUGGING
-      self.enable_caching           = ENABLE_CACHING
-      self.attribute_tag            = ATTRIBUTE_TAG
       self.label_tag                = LABEL_TAG
       self.label_class              = LABEL_CLASS
       self.non_text_fields          = NON_TEXT_FIELDS
+      self.per_page                 = PER_PAGE
+      self.pagination_limit         = PAGINATION_LIMIT
+      self.record_klass             = RECORD_KLASS
+      self.sticky_facets            = STICKY_FACETS
+      self.single_value_methods     = SINGLE_VALUE_METHODS
+      self.search_attributes        = SEARCH_ATTRIBUTES
+      self.search_klass             = SEARCH_KLASS
+      self.supplejack_fields        = SUPPLEJACK_FIELDS
+      self.special_fields           = SPECIAL_FIELDS
+      self.special_story_attributes = SPECIAL_STORY_ATTRIBUTES
+      self.timeout                  = TIMEOUT
+      self.url_format               = URL_FORMAT
+
       self
     end
   end

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -41,7 +41,7 @@ module Supplejack
     end
 
     def attributes
-      retrieve_attributes(ATTRIBUTES)
+      retrieve_attributes(ATTRIBUTES + Supplejack.special_story_attributes)
     end
 
     def api_attributes
@@ -234,7 +234,7 @@ module Supplejack
     def retrieve_attributes(attributes_list)
       {}.tap do |attributes|
         attributes_list.each do |attribute|
-          value = send(attribute)
+          value = ATTRIBUTES.include?(attribute) ? send(attribute) : @attributes[attribute]
           attributes[attribute] = value
         end
       end

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -8,9 +8,7 @@ end
 
 module Supplejack
   describe Story do
-    before do
-      Supplejack.stub(:enable_caching) { false }
-    end
+    before { Supplejack.stub(:enable_caching) { false } }
 
     describe '#initialize' do
       Supplejack::Story::ATTRIBUTES.reject { |a| a =~ /_at/ }.each do |attribute|
@@ -55,13 +53,30 @@ module Supplejack
     end
 
     describe '#attributes' do
-      it 'returns a hash of the set attributes' do
-        story = Supplejack::Story.new
+      let(:story) { Supplejack::Story.new({ name: 'Dogs', description: 'Hi', special_field: true }) }
 
-        story.name = 'Dogs'
-        story.description = 'Hi'
+      context 'when Supplejack special_story_attributes is not configured' do
+        it 'returns a hash of the set attributes' do
+          expect(story.attributes).to include(name: 'Dogs', description: 'Hi')
+        end
 
-        expect(story.attributes).to include(name: 'Dogs', description: 'Hi')
+        it 'doesnt return special_field' do
+          expect(story.attributes).not_to include(special_field: true)
+        end
+      end
+
+      context 'when Supplejack special_story_attributes is configured' do
+        before { Supplejack.special_story_attributes = %i[special_field] }
+
+        it 'returns a hash of the set attributes' do
+          expect(story.attributes).to include(name: 'Dogs', description: 'Hi')
+        end
+
+        it 'doesnt return special_field' do
+          expect(story.attributes).to include(special_field: true)
+        end
+
+        after { Supplejack.special_story_attributes = %i[] }
       end
     end
 


### PR DESCRIPTION
When API serializer is modified to return non standard fields(fields defined in Supplejack::Story::ATTRIBUTES)
client fails to communicate the new attribute to the user.

New Feature: allows special_story_attributes to be added as a config. Which will allow .attributes to return
non standard field received from the API.