### PR TITLE
STANDARD SUPPLEJACK EXCEPTION FOR FEATURED STORY

### DIFF
--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -133,10 +133,11 @@ module Supplejack
     end
 
     # Fetches featured stories
-    # Oliver Stigley July 2017
     #
     def self.featured
       get('/stories/featured')
+    rescue RestClient::ServiceUnavailable
+      raise Supplejack::ApiNotAvailable, 'API is not responding'
     end
 
     # Assigns the provided attributes to the Story object

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -448,6 +448,14 @@ module Supplejack
         Supplejack::Story.should_receive(:get).with('/stories/featured')
         Supplejack::Story.featured
       end
+
+      context 'when RestClient service unavailable' do
+        before { allow(Supplejack::Story).to receive(:get).and_raise(RestClient::ServiceUnavailable) }
+
+        it 'fetches stories from the api' do
+          expect { Supplejack::Story.featured }.to raise_error(Supplejack::ApiNotAvailable)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Supplejack has standard exceptions defined for API failure. This is not used universally.

Applying this to `Story.featured`.

Will require further work to get make this a global exception for all API calls.