### PR TITLE
STORY MODERATION USERNAME

### DIFF
--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -7,7 +7,7 @@ module Supplejack
     include ActiveModel::Conversion
 
     MODIFIABLE_ATTRIBUTES = %i[name description privacy copyright featured approved tags subjects record_ids count featured_at category].freeze
-    UNMODIFIABLE_ATTRIBUTES = %i[id created_at updated_at number_of_items contents cover_thumbnail creator user_id].freeze
+    UNMODIFIABLE_ATTRIBUTES = %i[id created_at updated_at number_of_items contents cover_thumbnail creator user_id username].freeze
     ATTRIBUTES = (MODIFIABLE_ATTRIBUTES + UNMODIFIABLE_ATTRIBUTES).freeze
 
     attr_accessor *ATTRIBUTES

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -408,6 +408,7 @@ module Supplejack
           creator: 'Wilfred',
           count: nil,
           user_id: nil,
+          username: nil,
           category: nil
         }
       end


### PR DESCRIPTION
**Acceptance Criteria**

The username is displayed on the moderation dashboard instead of the user id