### PR TITLE
REPOSITION STORY ITEMS

### DIFF
--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -103,17 +103,15 @@ module Supplejack
     # @return [ true, false ] True if the API response was successful, false if not.
     #
     def reposition_items(positions)
-      begin
-        self.class.post("/stories/#{id}/reposition_items", { user_key: api_key }, items: positions)
+      self.class.post("/stories/#{id}/reposition_items", { user_key: api_key }, items: positions)
 
-        Rails.cache.delete("/users/#{api_key}/stories") if Supplejack.enable_caching
+      Rails.cache.delete("/users/#{api_key}/stories") if Supplejack.enable_caching
 
-        true
-      rescue StandardError => e
-        self.errors = e.message
+      true
+    rescue StandardError => e
+      self.errors = e.message
 
-        false
-      end
+      false
     end
 
     # Fetches the Story information from the API again, in case it had changed.

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -103,8 +103,6 @@ module Supplejack
     # @return [ true, false ] True if the API response was successful, false if not.
     #
     def reposition_items(positions)
-      return false if new_record?
-
       begin
         self.class.post("/stories/#{id}/reposition_items", { user_key: api_key }, items: positions)
 

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -97,6 +97,27 @@ module Supplejack
       end
     end
 
+    # Executes a POST request to the API with the Story ID, the user's api_key &
+    # an Array of Hashes for item positions ex: [{ id: 'storyitemid', position: 100 }]
+    #
+    # @return [ true, false ] True if the API response was successful, false if not.
+    #
+    def reposition_items(positions)
+      return false if new_record?
+
+      begin
+        self.class.post("/stories/#{id}/reposition_items", { user_key: api_key }, items: positions)
+
+        Rails.cache.delete("/users/#{api_key}/stories") if Supplejack.enable_caching
+
+        true
+      rescue StandardError => e
+        self.errors = e.message
+
+        false
+      end
+    end
+
     # Fetches the Story information from the API again, in case it had changed.
     #
     # This can be useful if they items for a Story changed and you want the relation

--- a/lib/supplejack/story_item_relation.rb
+++ b/lib/supplejack/story_item_relation.rb
@@ -30,18 +30,6 @@ module Supplejack
       story_item.save
     end
 
-    def move_item(item_id, position)
-      response = post("/stories/#{story.id}/items/#{item_id}/moves", { api_key: story.api_key, user_key: story.api_key }, item_id: item_id, position: position)
-
-      build_items(response)
-
-      true
-    rescue StandardError => e
-      @errors = e.inspect
-
-      false
-    end
-
     def find(id)
       @items.detect { |i| i.id.to_s == id.to_s }
     end

--- a/spec/supplejack/story_item_relation_spec.rb
+++ b/spec/supplejack/story_item_relation_spec.rb
@@ -100,31 +100,6 @@ module Supplejack
       end
     end
 
-    describe '#move_item' do
-      let(:item) { relation.all.first }
-
-      before do
-        expect(relation).to receive(:post).with(
-          "/stories/#{supplejack_story.id}/items/#{item.id}/moves",
-          { api_key: 'foobar', user_key: 'foobar' },
-          item_id: 1, position: 2
-        ).and_return([
-                       { id: 2, type: 'embed', sub_type: 'supplejack_user', position: 1 },
-                       { id: 1, type: 'embed', sub_type: 'supplejack_user', position: 2 }
-                     ])
-      end
-
-      it 'calls the api move item endpoint with the new position' do
-        relation.move_item(item.id, 2)
-      end
-
-      it 'updates the items with the response' do
-        relation.move_item(item.id, 2)
-
-        expect(relation.all.first.id).to eq(2)
-      end
-    end
-
     context 'items array behaviour' do
       it 'executes array methods on the @items array' do
         expect(relation.any? { |x| x.id == 1 }).to eq(true)

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -218,6 +218,18 @@ module Supplejack
       end
     end
 
+    describe '#reposition_items' do
+      let(:user) { { api_key: 'foobar' } }
+      let(:story) { Supplejack::Story.new({ name: 'Story Name', description: 'desc', user: user, id: '123' }) }
+      let(:reposition_attributes) { [{ id: '111', position: 1 }, { id: '112', position: 2 }] }
+
+      it 'triggers a POST request to reposition_items' do
+        expect(Supplejack::Story).to receive(:post).with('/stories/123/reposition_items', { user_key: user[:api_key] }, items: reposition_attributes)
+
+        story.reposition_items(reposition_attributes)
+      end
+    end
+
     describe '#update_attributes' do
       let(:story) { Supplejack::Story.new(name: 'test', description: 'test') }
 


### PR DESCRIPTION
**Background**
Story items position was updated using `/moves` API which worked out the position for all items in regards to the change in the position of the given item. We have moved this logic to the front end. A new story endpoint have been created that allows bulk update of positions of story items.

**Changes made**
New method to access the new api endpoint added and old method deleted.