### PR TITLE
SJ CLIENT TO RETURN PROPER API ERROR MESSAGES: As SJ user, I want the client to return errors from the API so that I can communicate it with the frontend user.

### DIFF
--- a/lib/supplejack/request.rb
+++ b/lib/supplejack/request.rb
@@ -37,10 +37,14 @@ module Supplejack
     def post(path, params = {}, payload = {}, options = {})
       payload ||= {}
       log_request(:post, path, params, payload) do
-        response = RestClient::Request.execute(url: full_url(path, nil, params),
-                                               method: :post, payload: payload.to_json,
-                                               timeout: timeout(options),
-                                               headers: { content_type: :json, accept: :json })
+        response = begin
+                    RestClient::Request.execute(url: full_url(path, nil, params),
+                                                              method: :post, payload: payload.to_json,
+                                                              timeout: timeout(options),
+                                                              headers: { content_type: :json, accept: :json })
+                  rescue RestClient::ExceptionWithResponse => e
+                    e.response.body
+                  end
         begin
           JSON.parse(response)
         rescue StandardError
@@ -60,11 +64,18 @@ module Supplejack
     def put(path, params = {}, payload = {}, options = {})
       payload ||= {}
       log_request(:put, path, params, payload) do
-        response = RestClient::Request.execute(url: full_url(path, nil, params),
-                                               method: :put,
-                                               payload: payload.to_json,
-                                               timeout: timeout(options),
-                                               headers: { content_type: :json, accept: :json })
+
+
+        response = begin 
+                    RestClient::Request.execute(url: full_url(path, nil, params),
+                                                method: :put,
+                                                payload: payload.to_json,
+                                                timeout: timeout(options),
+                                                headers: { content_type: :json, accept: :json })
+                  rescue RestClient::ExceptionWithResponse => e
+                    e.response.body
+                  end
+
         begin
           JSON.parse(response)
         rescue StandardError
@@ -76,20 +87,18 @@ module Supplejack
     def patch(path, params = {}, payload = {}, options = {})
       payload ||= {}
       log_request(:patch, path, params, payload) do
-        response = RestClient::Request.execute(url: full_url(path, nil, params),
-                                               method: :patch,
-                                               payload: payload.to_json,
-                                               timeout: timeout(options),
-                                               headers: { content_type: :json, accept: :json })
-        # begin
-        #   response = RestClient::Request.execute(url: full_url(path, nil, params),
-        #                                          method: :patch,
-        #                                          payload: payload.to_json,
-        #                                          timeout: timeout(options),
-        #                                          headers: { content_type: :json, accept: :json })
-        # rescue RestClient::ExceptionWithResponse => e
-        #   e.response.body
-        # end
+        response = begin
+                    RestClient::Request.execute(url: full_url(path, nil, params),
+                                                          method: :patch,
+                                                          payload: payload.to_json,
+                                                          timeout: timeout(options),
+                                                          headers: { content_type: :json, accept: :json })
+                  rescue RestClient::ExceptionWithResponse => e
+
+                    binding.pry
+
+                    e.response.body
+                  end
 
         begin
           JSON.parse(response)

--- a/lib/supplejack/request.rb
+++ b/lib/supplejack/request.rb
@@ -81,6 +81,16 @@ module Supplejack
                                                payload: payload.to_json,
                                                timeout: timeout(options),
                                                headers: { content_type: :json, accept: :json })
+        # begin
+        #   response = RestClient::Request.execute(url: full_url(path, nil, params),
+        #                                          method: :patch,
+        #                                          payload: payload.to_json,
+        #                                          timeout: timeout(options),
+        #                                          headers: { content_type: :json, accept: :json })
+        # rescue RestClient::ExceptionWithResponse => e
+        #   e.response.body
+        # end
+
         begin
           JSON.parse(response)
         rescue StandardError

--- a/lib/supplejack/request.rb
+++ b/lib/supplejack/request.rb
@@ -38,13 +38,13 @@ module Supplejack
       payload ||= {}
       log_request(:post, path, params, payload) do
         response = begin
-                    RestClient::Request.execute(url: full_url(path, nil, params),
-                                                              method: :post, payload: payload.to_json,
-                                                              timeout: timeout(options),
-                                                              headers: { content_type: :json, accept: :json })
-                  rescue RestClient::ExceptionWithResponse => e
-                    e.response.body
-                  end
+          RestClient::Request.execute(url: full_url(path, nil, params),
+                                      method: :post, payload: payload.to_json,
+                                      timeout: timeout(options),
+                                      headers: { content_type: :json, accept: :json })
+        rescue RestClient::ExceptionWithResponse => e
+          e.response.body
+        end
         begin
           JSON.parse(response)
         rescue StandardError
@@ -64,17 +64,15 @@ module Supplejack
     def put(path, params = {}, payload = {}, options = {})
       payload ||= {}
       log_request(:put, path, params, payload) do
-
-
-        response = begin 
-                    RestClient::Request.execute(url: full_url(path, nil, params),
-                                                method: :put,
-                                                payload: payload.to_json,
-                                                timeout: timeout(options),
-                                                headers: { content_type: :json, accept: :json })
-                  rescue RestClient::ExceptionWithResponse => e
-                    e.response.body
-                  end
+        response = begin
+          RestClient::Request.execute(url: full_url(path, nil, params),
+                                      method: :put,
+                                      payload: payload.to_json,
+                                      timeout: timeout(options),
+                                      headers: { content_type: :json, accept: :json })
+        rescue RestClient::ExceptionWithResponse => e
+          e.response.body
+        end
 
         begin
           JSON.parse(response)
@@ -88,17 +86,14 @@ module Supplejack
       payload ||= {}
       log_request(:patch, path, params, payload) do
         response = begin
-                    RestClient::Request.execute(url: full_url(path, nil, params),
-                                                          method: :patch,
-                                                          payload: payload.to_json,
-                                                          timeout: timeout(options),
-                                                          headers: { content_type: :json, accept: :json })
-                  rescue RestClient::ExceptionWithResponse => e
-
-                    binding.pry
-
-                    e.response.body
-                  end
+          RestClient::Request.execute(url: full_url(path, nil, params),
+                                      method: :patch,
+                                      payload: payload.to_json,
+                                      timeout: timeout(options),
+                                      headers: { content_type: :json, accept: :json })
+        rescue RestClient::ExceptionWithResponse => e
+          e.response.body
+        end
 
         begin
           JSON.parse(response)

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -6,7 +6,7 @@ module Supplejack
     extend ActiveModel::Naming
     include ActiveModel::Conversion
 
-    MODIFIABLE_ATTRIBUTES = %i[name description privacy copyright featured approved tags subjects record_ids count featured_at category].freeze
+    MODIFIABLE_ATTRIBUTES = %i[name description privacy copyright featured approved tags subjects record_ids count featured_at category errors].freeze
     UNMODIFIABLE_ATTRIBUTES = %i[id created_at updated_at number_of_items contents cover_thumbnail creator user_id username].freeze
     ATTRIBUTES = (MODIFIABLE_ATTRIBUTES + UNMODIFIABLE_ATTRIBUTES).freeze
 
@@ -70,7 +70,6 @@ module Supplejack
       # rubocop:enable Style/ConditionalAssignment
 
       Rails.cache.delete("/users/#{api_key}/stories") if Supplejack.enable_caching
-
       true
     rescue StandardError => e
       self.errors = e.message

--- a/spec/supplejack/request_spec.rb
+++ b/spec/supplejack/request_spec.rb
@@ -16,9 +16,7 @@ module Supplejack
     end
 
     describe '#get' do
-      before(:each) do
-        RestClient::Request.stub(:execute).and_return(%( {"search": {}} ))
-      end
+      before(:each) { RestClient::Request.stub(:execute).and_return(%( {"search": {}} )) }
 
       it 'serializes the parameters in the url' do
         RestClient::Request.should_receive(:execute).with(url: "http://api.org/records.json?#{{ and: { name: 'John' } }.to_query}&api_key=123", method: :get, read_timeout: 20)
@@ -76,9 +74,7 @@ module Supplejack
     end
 
     describe '#post' do
-      before(:each) do
-        RestClient::Request.stub(:execute)
-      end
+      before(:each) { RestClient::Request.stub(:execute) }
 
       it 'executes a post request' do
         RestClient::Request.should_receive(:execute).with(hash_including(method: :post))
@@ -108,9 +104,7 @@ module Supplejack
     end
 
     describe '#delete' do
-      before(:each) do
-        RestClient::Request.stub(:execute)
-      end
+      before(:each) { RestClient::Request.stub(:execute) }
 
       it 'executes a delete request' do
         RestClient::Request.should_receive(:execute).with(hash_including(method: :delete))
@@ -124,9 +118,7 @@ module Supplejack
     end
 
     describe '#put' do
-      before(:each) do
-        RestClient::Request.stub(:execute)
-      end
+      before(:each) { RestClient::Request.stub(:execute) }
 
       it 'executes a put request' do
         RestClient::Request.should_receive(:execute).with(hash_including(method: :put))
@@ -151,6 +143,40 @@ module Supplejack
       it 'parses the JSON response' do
         RestClient::Request.stub(:execute) { { user: { name: 'John' } }.to_json }
         @test.put('/users/1', {}, {}).should eq('user' => { 'name' => 'John' })
+      end
+    end
+
+    describe '#patch' do
+      before(:each) { RestClient::Request.stub(:execute) }
+
+      it 'executes a patch request' do
+        RestClient::Request.should_receive(:execute).with(hash_including(method: :patch))
+
+        @test.patch('/records/1/ucm/1')
+      end
+
+      it 'passes the payload along' do
+        RestClient::Request.should_receive(:execute).with(hash_including(payload: { name: 1 }.to_json))
+
+        @test.put('/records/1/ucm/1', {}, name: 1)
+      end
+
+      it 'adds the extra parameters to the patch request' do
+        @test.should_receive(:full_url).with('/records/1/ucm/1', nil, api_key: '12344')
+
+        @test.patch('/records/1/ucm/1', { api_key: '12344' }, {})
+      end
+
+      it 'adds json headers and converts the payload into json' do
+        RestClient::Request.should_receive(:execute).with(hash_including(headers: { content_type: :json, accept: :json }, payload: { records: [1, 2, 3] }.to_json))
+
+        @test.patch('/records/1/ucm/1', {}, records: [1, 2, 3])
+      end
+
+      it 'parses the JSON response' do
+        RestClient::Request.stub(:execute) { { user: { name: 'John' } }.to_json }
+
+        @test.patch('/users/1', {}, {}).should eq('user' => { 'name' => 'John' })
       end
     end
 

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -145,7 +145,7 @@ module Supplejack
 
     describe '#save' do
       context 'Story is a new_record' do
-        let(:attributes) { { name: 'Story Name', description: nil, privacy: nil, copyright: nil, featured_at: nil, featured: nil, approved: nil, tags: nil, subjects: nil, record_ids: nil, count: nil, category: nil } }
+        let(:attributes) { { name: 'Story Name', description: nil, errors: nil, privacy: nil, copyright: nil, featured_at: nil, featured: nil, approved: nil, tags: nil, subjects: nil, record_ids: nil, count: nil, category: nil } }
         let(:user) { { api_key: 'foobar' } }
         let(:story) { Supplejack::Story.new(attributes.merge(user: user)) }
 
@@ -155,6 +155,7 @@ module Supplejack
               'id' => 'new-id',
               'name' => attributes[:name],
               'description' => '',
+              'errors' => nil,
               'tags' => [],
               'subjects' => [],
               'contents' => [],
@@ -188,7 +189,7 @@ module Supplejack
       end
 
       context 'story is not new' do
-        let(:attributes) { { name: 'Story Name', description: 'desc', privacy: nil, copyright: nil, featured_at: nil, featured: nil, approved: nil, tags: nil, subjects: nil, record_ids: nil, count: nil, category: nil } }
+        let(:attributes) { { name: 'Story Name', description: 'desc', errors: nil, privacy: nil, copyright: nil, featured_at: nil, featured: nil, approved: nil, tags: nil, subjects: nil, record_ids: nil, count: nil, category: nil } }
         let(:user) { { api_key: 'foobar' } }
         let(:story) { Supplejack::Story.new(attributes.merge(user: user, id: '123')) }
 
@@ -198,6 +199,7 @@ module Supplejack
               'id' => 'new-id',
               'name' => attributes[:name],
               'description' => 'desc',
+              'errors' => nil,
               'tags' => [],
               'subjects' => [],
               'contents' => [],
@@ -403,6 +405,7 @@ module Supplejack
         {
           name: 'foo',
           description: 'desc',
+          errors: nil,
           privacy: nil,
           copyright: nil,
           featured: nil,


### PR DESCRIPTION
**Acceptance Criteria**
- SJ client methods return errors to the application and not just 400

**Notes**
- Related DNZ story 
https://www.pivotaltracker.com/story/show/179369096





