### PR TITLE
OPTIMIZE API CALL ON MULTIPLE ADD: As Frances, I want the API to be optimized, so that my interactions are faster when I add a record to multiple stories

### DIFF
--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -110,6 +110,18 @@ module Supplejack
       false
     end
 
+    def multiple_add(stories)
+      self.class.post('/stories/multple_add', { user_key: api_key }, stories: stories)
+
+      Rails.cache.delete("/stories/multiple_add") if Supplejack.enable_caching
+
+      true
+    rescue StandardError => e
+      self.errors = e.message
+
+      false 
+    end
+
     # Fetches the Story information from the API again, in case it had changed.
     #
     # This can be useful if they items for a Story changed and you want the relation

--- a/lib/supplejack/story.rb
+++ b/lib/supplejack/story.rb
@@ -101,8 +101,6 @@ module Supplejack
     def reposition_items(positions)
       response = self.class.post("/stories/#{id}/reposition_items", { user_key: api_key }, items: positions)
 
-      Rails.cache.delete("/users/#{api_key}/stories") if Supplejack.enable_caching
-
       error?(response)
     rescue StandardError => e
       self.errors = e.message
@@ -111,15 +109,23 @@ module Supplejack
     end
 
     def multiple_add(stories)
-      self.class.post('/stories/multple_add', { user_key: api_key }, stories: stories)
-
-      Rails.cache.delete("/stories/multiple_add") if Supplejack.enable_caching
+      self.class.post('/stories/multiple_add', { user_key: api_key }, stories: stories)
 
       true
     rescue StandardError => e
       self.errors = e.message
 
-      false 
+      false
+    end
+
+    def multiple_remove(stories)
+      self.class.post('/stories/multiple_remove', { user_key: api_key }, stories: stories)
+
+      true
+    rescue StandardError => e
+      self.errors = e.message
+
+      false
     end
 
     # Fetches the Story information from the API again, in case it had changed.

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -250,6 +250,18 @@ module Supplejack
       end
     end
 
+    describe '#multiple_add' do
+      let(:user) { { api_key: 'foobar' } }
+      let(:story) { Supplejack::Story.new({ name: 'Story Name', description: 'desc', user: user, id: '123' }) }
+      let(:stories) { [{ id: '1', items: [] }, { id: '2', items: [] }] }
+
+      it 'triggers a POST request to reposition_items' do
+        expect(Supplejack::Story).to receive(:post).with('/stories/multiple_add', { user_key: user[:api_key] }, stories: stories)
+
+        story.multiple_add(stories)
+      end
+    end
+
     describe '#update_attributes' do
       let(:story) { described_class.new(name: 'test', description: 'test') }
 

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -252,23 +252,23 @@ module Supplejack
 
     describe '#multiple_add' do
       let(:user) { { api_key: 'foobar' } }
-      let(:story) { Supplejack::Story.new({ name: 'Story Name', description: 'desc', user: user, id: '123' }) }
+      let(:story) { described_class.new({ name: 'Story Name', description: 'desc', user: user, id: '123' }) }
       let(:stories) { [{ id: '1', items: [] }, { id: '2', items: [] }] }
 
       it 'triggers a POST request to multiple_add' do
-        expect(Supplejack::Story).to receive(:post).with('/stories/multiple_add', { user_key: user[:api_key] }, stories: stories)
+        expect(described_class).to receive(:post).with('/stories/multiple_add', { user_key: user[:api_key] }, stories: stories)
 
         story.multiple_add(stories)
       end
     end
 
-    describe '#multiple_add' do
+    describe '#multiple_remove' do
       let(:user) { { api_key: 'foobar' } }
-      let(:story) { Supplejack::Story.new({ name: 'Story Name', description: 'desc', user: user, id: '123' }) }
+      let(:story) { described_class.new({ name: 'Story Name', description: 'desc', user: user, id: '123' }) }
       let(:stories) { [{ id: '1', items: [1] }, { id: '2', items: [2] }] }
 
       it 'triggers a POST request to multiple_add' do
-        expect(Supplejack::Story).to receive(:post).with('/stories/multiple_remove', { user_key: user[:api_key] }, stories: stories)
+        expect(described_class).to receive(:post).with('/stories/multiple_remove', { user_key: user[:api_key] }, stories: stories)
 
         story.multiple_remove(stories)
       end

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -255,10 +255,22 @@ module Supplejack
       let(:story) { Supplejack::Story.new({ name: 'Story Name', description: 'desc', user: user, id: '123' }) }
       let(:stories) { [{ id: '1', items: [] }, { id: '2', items: [] }] }
 
-      it 'triggers a POST request to reposition_items' do
+      it 'triggers a POST request to multiple_add' do
         expect(Supplejack::Story).to receive(:post).with('/stories/multiple_add', { user_key: user[:api_key] }, stories: stories)
 
         story.multiple_add(stories)
+      end
+    end
+
+    describe '#multiple_add' do
+      let(:user) { { api_key: 'foobar' } }
+      let(:story) { Supplejack::Story.new({ name: 'Story Name', description: 'desc', user: user, id: '123' }) }
+      let(:stories) { [{ id: '1', items: [1] }, { id: '2', items: [2] }] }
+
+      it 'triggers a POST request to multiple_add' do
+        expect(Supplejack::Story).to receive(:post).with('/stories/multiple_remove', { user_key: user[:api_key] }, stories: stories)
+
+        story.multiple_remove(stories)
       end
     end
 


### PR DESCRIPTION
**Acceptance Criteria**
- One API call only is made when adding/removing to multiple stories at once

**Notes**
- Follows https://www.pivotaltracker.com/story/show/179369427 and https://www.pivotaltracker.com/story/show/178685704
- Feature is part of the open sourced project 
