### PR TITLE
REFACTOR OLD SPECS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rspec
+
 inherit_from: .rubocop_todo.yml
 
 AllCops:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -70,3 +70,7 @@ Style/FormatStringToken:
 # URISchemes: http, https
 Layout/LineLength:
   Max: 270
+
+RSpec/MessageSpies:
+  Exclude:
+    - 'spec/supplejack/**/*.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -74,3 +74,9 @@ Layout/LineLength:
 RSpec/MessageSpies:
   Exclude:
     - 'spec/supplejack/**/*.rb'
+
+RSpec/MultipleExpectations:
+  Max: 2
+
+RSpec/ExampleLength:
+  Max: 7

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ SimpleCov.start
 
 RSpec.configure do |config|
   config.mock_with :rspec
-
+  config.raise_errors_for_deprecations!
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 end

--- a/spec/supplejack/concept_spec.rb
+++ b/spec/supplejack/concept_spec.rb
@@ -52,7 +52,7 @@ module Supplejack
       expect { concept.something }.to raise_error(NoMethodError)
     end
 
-    it 'should return the value when is present in the attributes' do
+    it 'returns the value when is present in the attributes' do
       concept = SupplejackConcept.new(weird_method: 'Something')
 
       expect(concept.weird_method).to eq 'Something'
@@ -99,7 +99,7 @@ module Supplejack
     end
 
     describe '#find' do
-      context 'single concept' do
+      context 'with single concept' do
         it 'raises a Supplejack::ConceptNotFound' do
           allow(SupplejackConcept).to receive(:get).and_raise(RestClient::ResourceNotFound)
 
@@ -111,7 +111,8 @@ module Supplejack
         end
 
         it 'requests the concept from the API' do
-          expect(SupplejackConcept).to receive(:get).with('/concepts/1', {}).and_return('concept' => {})
+          allow(SupplejackConcept).to receive(:get).with('/concepts/1', {}).and_return('concept' => {})
+
           SupplejackConcept.find(1)
         end
 
@@ -120,14 +121,13 @@ module Supplejack
           concept = SupplejackConcept.find(1)
 
           expect(concept.class).to eq SupplejackConcept
-          expect(concept.id).to eq 1
           expect(concept.name).to eq 'Wellington'
         end
 
         it 'send the fields defined in the configuration' do
-          allow(Supplejack).to receive(:fields) { %i[verbose default] }
+          allow(Supplejack).to receive(:fields).and_return(%i[verbose default])
+          allow(SupplejackConcept).to receive(:get).with('/concepts/1', {}).and_return('concept' => {})
 
-          expect(SupplejackConcept).to receive(:get).with('/concepts/1', {}).and_return('concept' => {})
           SupplejackConcept.find(1)
         end
       end
@@ -135,7 +135,7 @@ module Supplejack
 
     describe '#all' do
       it 'calls the get method' do
-        expect(SupplejackConcept).to receive(:get).with('/concepts', {}).and_return({})
+        allow(SupplejackConcept).to receive(:get).with('/concepts', {}).and_return({})
 
         SupplejackConcept.all
       end

--- a/spec/supplejack/concept_spec.rb
+++ b/spec/supplejack/concept_spec.rb
@@ -36,7 +36,7 @@ module Supplejack
 
     it 'handles a string as params' do
       concept = SupplejackConcept.new('')
-      
+
       expect(concept.attributes).to eq({})
     end
 
@@ -48,26 +48,26 @@ module Supplejack
 
     it 'raises a NoMethodError for every method call that doesn\'t have a key in the attributes' do
       concept = SupplejackConcept.new
-      
+
       expect { concept.something }.to raise_error(NoMethodError)
     end
 
     it 'should return the value when is present in the attributes' do
       concept = SupplejackConcept.new(weird_method: 'Something')
-      
+
       expect(concept.weird_method).to eq 'Something'
     end
 
     describe 'id' do
       it 'returns the concept_id' do
         concept = SupplejackConcept.new('concept_id' => '95')
-        
+
         expect(concept.id).to eq 95
       end
 
       it 'returns the id' do
         concept = SupplejackConcept.new('id' => '96')
-        
+
         expect(concept.id).to eq 96
       end
     end

--- a/spec/supplejack/concept_spec.rb
+++ b/spec/supplejack/concept_spec.rb
@@ -24,53 +24,61 @@ module Supplejack
   describe Concept do
     it 'initializes its attributes from a JSON string' do
       concept = SupplejackConcept.new(%({"name": "Name", "prefLabel": "Label"}))
-      concept.attributes.should eq(name: 'Name', prefLabel: 'Label')
+
+      expect(concept.attributes).to eq(name: 'Name', prefLabel: 'Label')
     end
 
     it 'handles nil params' do
       concept = SupplejackConcept.new(nil)
-      concept.attributes.should eq({})
+
+      expect(concept.attributes).to eq({})
     end
 
     it 'handles a string as params' do
       concept = SupplejackConcept.new('')
-      concept.attributes.should eq({})
+      
+      expect(concept.attributes).to eq({})
     end
 
     it 'handles a array as params' do
       concept = SupplejackConcept.new([])
-      concept.attributes.should eq({})
+
+      expect(concept.attributes).to eq({})
     end
 
     it 'raises a NoMethodError for every method call that doesn\'t have a key in the attributes' do
       concept = SupplejackConcept.new
+      
       expect { concept.something }.to raise_error(NoMethodError)
     end
 
     it 'should return the value when is present in the attributes' do
       concept = SupplejackConcept.new(weird_method: 'Something')
-      concept.weird_method.should eq 'Something'
+      
+      expect(concept.weird_method).to eq 'Something'
     end
 
     describe 'id' do
       it 'returns the concept_id' do
         concept = SupplejackConcept.new('concept_id' => '95')
-        concept.id.should eq 95
+        
+        expect(concept.id).to eq 95
       end
 
       it 'returns the id' do
         concept = SupplejackConcept.new('id' => '96')
-        concept.id.should eq 96
+        
+        expect(concept.id).to eq 96
       end
     end
 
     describe '#name' do
       it 'returns the title attribute value' do
-        SupplejackConcept.new(name: 'Name').name.should eq 'Name'
+        expect(SupplejackConcept.new(name: 'Name').name).to eq 'Name'
       end
 
       it 'returns "Unknown" for concepts without a title' do
-        SupplejackConcept.new(name: nil).name.should eq 'Unknown'
+        expect(SupplejackConcept.new(name: nil).name).to eq 'Unknown'
       end
     end
 
@@ -78,12 +86,14 @@ module Supplejack
       describe attr.to_s do
         it "returns the #{attr}" do
           concept = SupplejackConcept.new(attr => 1)
-          concept.send(attr).should eq 1
+
+          expect(concept.send(attr)).to eq 1
         end
 
         it 'returns the nil' do
           concept = SupplejackConcept.new({})
-          concept.send(attr).should be_nil
+
+          expect(concept.send(attr)).to be_nil
         end
       end
     end
@@ -91,7 +101,8 @@ module Supplejack
     describe '#find' do
       context 'single concept' do
         it 'raises a Supplejack::ConceptNotFound' do
-          SupplejackConcept.stub(:get).and_raise(RestClient::ResourceNotFound)
+          allow(SupplejackConcept).to receive(:get).and_raise(RestClient::ResourceNotFound)
+
           expect { SupplejackConcept.find(1) }.to raise_error(Supplejack::ConceptNotFound)
         end
 
@@ -100,21 +111,23 @@ module Supplejack
         end
 
         it 'requests the concept from the API' do
-          SupplejackConcept.should_receive(:get).with('/concepts/1', {}).and_return('concept' => {})
+          expect(SupplejackConcept).to receive(:get).with('/concepts/1', {}).and_return('concept' => {})
           SupplejackConcept.find(1)
         end
 
         it 'initializes a new SupplejackConcept object' do
-          SupplejackConcept.stub(:get).and_return('concept_id' => '1', 'name' => 'Wellington')
+          allow(SupplejackConcept).to receive(:get).and_return('concept_id' => '1', 'name' => 'Wellington')
           concept = SupplejackConcept.find(1)
-          concept.class.should eq SupplejackConcept
-          concept.id.should eq 1
-          concept.name.should eq 'Wellington'
+
+          expect(concept.class).to eq SupplejackConcept
+          expect(concept.id).to eq 1
+          expect(concept.name).to eq 'Wellington'
         end
 
         it 'send the fields defined in the configuration' do
-          Supplejack.stub(:fields) { %i[verbose default] }
-          SupplejackConcept.should_receive(:get).with('/concepts/1', {}).and_return('concept' => {})
+          allow(Supplejack).to receive(:fields) { %i[verbose default] }
+
+          expect(SupplejackConcept).to receive(:get).with('/concepts/1', {}).and_return('concept' => {})
           SupplejackConcept.find(1)
         end
       end
@@ -122,7 +135,8 @@ module Supplejack
 
     describe '#all' do
       it 'calls the get method' do
-        SupplejackConcept.should_receive(:get).with('/concepts', {}).and_return({})
+        expect(SupplejackConcept).to receive(:get).with('/concepts', {}).and_return({})
+
         SupplejackConcept.all
       end
     end

--- a/spec/supplejack/controllers/helpers_spec.rb
+++ b/spec/supplejack/controllers/helpers_spec.rb
@@ -26,6 +26,7 @@ module FakeRoutes
 end
 
 def mock_record(stubs = {})
+  # rubocop:disable RSpec/VerifiedDoubles
   (@mock_record ||= double(:record).as_null_object).tap do |record|
     unless stubs.empty?
       stubs.each do |key, value|
@@ -33,6 +34,7 @@ def mock_record(stubs = {})
       end
     end
   end
+  # rubocop:enable RSpec/VerifiedDoubles
 end
 
 class AdvancedSearch < Supplejack::Search

--- a/spec/supplejack/controllers/helpers_spec.rb
+++ b/spec/supplejack/controllers/helpers_spec.rb
@@ -41,273 +41,262 @@ end
 module Supplejack
   module Controllers
     describe Helpers do
+      let(:controller) { ActionController::Base.new }
+
       before do
-        @c = ActionController::Base.new
-        @c.class.send(:include, FakeRoutes)
-        @c.class.send(:include, Supplejack::Controllers::Helpers)
-        @c.class.send(:include, ActionView::Helpers)
+        controller.class.send(:include, FakeRoutes)
+        controller.class.send(:include, Supplejack::Controllers::Helpers)
+        controller.class.send(:include, ActionView::Helpers)
       end
 
       describe '#search' do
-        before(:each) do
-          allow(@c).to receive(:params) { { text: 'dog' } }
-        end
+        before { allow(controller).to receive(:params) { { text: 'dog' } } }
 
         it 'initializes a search object with the params' do
           expect(Supplejack::Search).to receive(:new).with(text: 'dog')
 
-          @c.search
+          controller.search
         end
 
         it 'tries to initialize with params[:search] ' do
-          allow(@c).to receive(:params) { { search: { text: 'cat' } } }
+          allow(controller).to receive(:params) { { search: { text: 'cat' } } }
 
           expect(Supplejack::Search).to receive(:new).with(text: 'cat')
 
-          @c.search
+          controller.search
         end
 
         it 'initializes the search with the passed params' do
           expect(Supplejack::Search).to receive(:new).with(text: 'elephant')
 
-          @c.search(text: 'elephant')
+          controller.search(text: 'elephant')
         end
 
         it 'uses the special Search class' do
           allow(Supplejack).to receive(:search_klass) { 'AdvancedSearch' }
           expect(AdvancedSearch).to receive(:new).with(text: 'dog')
 
-          @c.search
+          controller.search
         end
 
         it 'memoizes the search object' do
-          @search = Supplejack::Search.new
-          expect(Supplejack::Search).to receive(:new).once.and_return(@search)
+          expect(Supplejack::Search).to receive(:new).once.and_return(Supplejack::Search.new)
 
-          @c.search
-          @c.search
+          controller.search
+          controller.search
         end
       end
 
       describe 'attribute' do
         context 'nested attributes' do
-          before(:each) do
-            @user_set = Supplejack::UserSet.new(user: { name: 'Juanito' })
-          end
+          let(:user_set) { Supplejack::UserSet.new(user: { name: 'Juanito' }) }
 
           it 'supports nested attributes' do
-            expect(@c.attribute(@user_set, 'user.name')).to eq %(<p><strong>User.name: </strong>Juanito</p>)
+            expect(controller.attribute(user_set, 'user.name')).to eq %(<p><strong>User.name: </strong>Juanito</p>)
           end
 
           it 'correctly uses the translation for the label' do
             expect(I18n).to receive(:t).with('supplejack_user_sets.user.name', default: 'User.name') { 'By' }
 
-            @c.attribute(@user_set, 'user.name')
+            controller.attribute(user_set, 'user.name')
           end
         end
 
         context 'single value' do
-          before(:each) do
-            @record = mock_record(title: 'Wellington', content_partner: '', description: nil)
-          end
+          let(:record) { mock_record(title: 'Wellington', content_partner: '', description: nil) }
 
           it 'returns the attribute name and its value' do
-            expect(@c.attribute(@record, :title)).to eq %(<p><strong>Title: </strong>Wellington</p>)
+            expect(controller.attribute(record, :title)).to eq %(<p><strong>Title: </strong>Wellington</p>)
           end
 
           it 'uses a div instead of a p' do
-            expect(@c.attribute(@record, :title, tag: :div)).to eq %(<div><strong>Title: </strong>Wellington</div>)
+            expect(controller.attribute(record, :title, tag: :div)).to eq %(<div><strong>Title: </strong>Wellington</div>)
           end
 
           it 'does not use a tag if tag option is nil' do
-            expect(@c.attribute(@record, :title, tag: nil)).to eq %(<strong>Title: </strong>Wellington)
+            expect(controller.attribute(record, :title, tag: nil)).to eq %(<strong>Title: </strong>Wellington)
           end
 
           it 'truncates the content to 5 characters' do
-            expect(@c.attribute(@record, :title, limit: 8)).to eq %(<p><strong>Title: </strong>Welli...</p>)
+            expect(controller.attribute(record, :title, limit: 8)).to eq %(<p><strong>Title: </strong>Welli...</p>)
           end
 
           it 'puts the label and the field value on seperate lines if label_inle is false' do
-            expect(@c.attribute(@record, :title, label_inline: false)).to eq %(<p><strong>Title: </strong><br/>Wellington</p>)
+            expect(controller.attribute(record, :title, label_inline: false)).to eq %(<p><strong>Title: </strong><br/>Wellington</p>)
           end
 
           it 'removes the label' do
-            expect(@c.attribute(@record, :title, label: false)).to eq %(<p>Wellington</p>)
+            expect(controller.attribute(record, :title, label: false)).to eq %(<p>Wellington</p>)
           end
 
           it 'doesn\'t display anything when the value is nil' do
-            expect(@c.attribute(@record, :content_partner)).to be nil
-            expect(@c.attribute(@record, :description)).to be nil
+            expect(controller.attribute(record, :content_partner)).to be nil
+            expect(controller.attribute(record, :description)).to be nil
           end
 
           it 'displays span label tag' do
-            expect(@c.attribute(@record, :title, label_tag: :span)).to eq %(<p><span>Title: </span>Wellington</p>)
+            expect(controller.attribute(record, :title, label_tag: :span)).to eq %(<p><span>Title: </span>Wellington</p>)
           end
 
           it 'displays label tag with a class' do
-            expect(@c.attribute(@record, :title, label_class: 'label')).to eq %(<p><strong class="label">Title: </strong>Wellington</p>)
+            expect(controller.attribute(record, :title, label_class: 'label')).to eq %(<p><strong class="label">Title: </strong>Wellington</p>)
           end
 
           it 'uses the translation key' do
             expect(I18n).to receive(:t).with('item.key', default: 'Title').and_return('Title')
 
-            @c.attribute(@record, :title, trans_key: 'item.key')
+            controller.attribute(record, :title, trans_key: 'item.key')
           end
 
           context ':link => true' do
             it 'converts it to a URL when value is a url' do
               url = 'http://google.com/images'
-              @record = mock_record(landing_url: url)
+              record = mock_record(landing_url: url)
 
-              expect(@c.attribute(@record, :landing_url, link: true)).to eq %(<p><strong>Landing_url: </strong>#{@c.link_to url, url}</p>)
+              expect(controller.attribute(record, :landing_url, link: true)).to eq %(<p><strong>Landing_url: </strong>#{controller.link_to url, url}</p>)
             end
 
             it 'links to the URL when the value contains both a URL and text' do
               url = 'http://google.com/images'
-              @record = mock_record(source: "Image location #{url}")
+              record = mock_record(source: "Image location #{url}")
 
-              expect(@c.attribute(@record, :source, link: true)).to eq %(<p><strong>Source: </strong>Image location #{@c.link_to url, url}</p>)
+              expect(controller.attribute(record, :source, link: true)).to eq %(<p><strong>Source: </strong>Image location #{controller.link_to url, url}</p>)
             end
 
             it 'converts it to a URL with the url pattern in :link and replaces the value' do
-              @record = mock_record(subject: ['New Zealand'])
+              record = mock_record(subject: ['New Zealand'])
 
-              expect(@c.attribute(@record, :subject, link: '/records?i[subject_text]={{value}}')).to eq %(<p><strong>Subject: </strong>#{@c.link_to 'New Zealand', '/records?i[subject_text]=New Zealand'}</p>)
+              expect(controller.attribute(record, :subject, link: '/records?i[subject_text]={{value}}')).to eq %(<p><strong>Subject: </strong>#{controller.link_to 'New Zealand', '/records?i[subject_text]=New Zealand'}</p>)
             end
 
             it 'returns nothing when value is nil' do
-              expect(@c.attribute(@record, :description, link: true)).to be nil
+              expect(controller.attribute(record, :description, link: true)).to be nil
             end
           end
 
           it 'returns nothing when value is "Not specified"' do
             record = mock_record(description: 'Not specified')
 
-            expect(@c.attribute(record, :description)).to be nil
+            expect(controller.attribute(record, :description)).to be nil
           end
 
           it 'adds extra_html inside of the <p>' do
-            expect(@c.attribute(@record, :title, extra_html: @c.content_tag(:span, 'Hi!'))).to eq %(<p><strong>Title: </strong>Wellington<span>Hi!</span></p>)
+            expect(controller.attribute(record, :title, extra_html: controller.content_tag(:span, 'Hi!'))).to eq %(<p><strong>Title: </strong>Wellington<span>Hi!</span></p>)
           end
 
           context 'default HTML values' do
             it 'uses the tag defined in the config' do
               allow(Supplejack).to receive(:attribute_tag) { :span }
 
-              expect(@c.attribute(@record, :title)).to eq %(<span><strong>Title: </strong>Wellington</span>)
+              expect(controller.attribute(record, :title)).to eq %(<span><strong>Title: </strong>Wellington</span>)
             end
 
             it 'uses the label tag defined in the config' do
               allow(Supplejack).to receive(:label_tag) { :b }
 
-              expect(@c.attribute(@record, :title)).to eq %(<p><b>Title: </b>Wellington</p>)
+              expect(controller.attribute(record, :title)).to eq %(<p><b>Title: </b>Wellington</p>)
             end
 
             it 'uses the label class defined in the config' do
               allow(Supplejack).to receive(:label_class) { 'label' }
 
-              expect(@c.attribute(@record, :title)).to eq %(<p><strong class="label">Title: </strong>Wellington</p>)
+              expect(controller.attribute(record, :title)).to eq %(<p><strong class="label">Title: </strong>Wellington</p>)
             end
           end
         end
 
         context 'multiple values' do
-          before(:each) do
-            @record = mock_record(category: %w[Images Videos])
-          end
+          let(:record) { mock_record(category: %w[Images Videos]) }
 
           it 'displays the values separated by commas' do
-            expect(@c.attribute(@record, :category)).to eq %(<p><strong>Category: </strong>Images, Videos</p>)
+            expect(controller.attribute(record, :category)).to eq %(<p><strong>Category: </strong>Images, Videos</p>)
           end
 
           it 'displays the values separated by another delimiter' do
-            expect(@c.attribute(@record, :category, delimiter: ':')).to eq %(<p><strong>Category: </strong>Images:Videos</p>)
+            expect(controller.attribute(record, :category, delimiter: ':')).to eq %(<p><strong>Category: </strong>Images:Videos</p>)
           end
 
           it 'limits the amount of values returned' do
-            expect(@c.attribute(@record, :category, limit: 1)).to eq %(<p><strong>Category: </strong>Images</p>)
+            expect(controller.attribute(record, :category, limit: 1)).to eq %(<p><strong>Category: </strong>Images</p>)
           end
 
           it 'limits the amount of values returned when less than 20' do
-            allow(@record).to receive(:category) { (1..30).to_a.map(&:to_s) }
+            allow(record).to receive(:category) { (1..30).to_a.map(&:to_s) }
 
-            expect(@c.attribute(@record, :category, limit: 10)).to eq %(<p><strong>Category: </strong>1, 2, 3, 4, 5, 6, 7, 8, 9, 10</p>)
+            expect(controller.attribute(record, :category, limit: 10)).to eq %(<p><strong>Category: </strong>1, 2, 3, 4, 5, 6, 7, 8, 9, 10</p>)
           end
 
           it 'generates links for every value' do
-            @link1 = @c.link_to('Images', "/records?#{{ i: { category: 'Images' } }.to_query}")
-            @link2 = @c.link_to('Videos', "/records?#{{ i: { category: 'Videos' } }.to_query}")
+            link1 = controller.link_to('Images', "/records?#{{ i: { category: 'Images' } }.to_query}")
+            link2 = controller.link_to('Videos', "/records?#{{ i: { category: 'Videos' } }.to_query}")
 
-            expect(@c.attribute(@record, :category, link_path: 'records_path')).to eq %(<p><strong>Category: </strong>#{@link1}, #{@link2}</p>)
+            expect(controller.attribute(record, :category, link_path: 'records_path')).to eq %(<p><strong>Category: </strong>#{link1}, #{link2}</p>)
           end
 
           it 'converts every value to a URL when :link => true and value is a url' do
             url1 = 'http://google.com/images'
             url2 = 'http://yahoo.com/photos'
-            @record = mock_record(landing_url: [url1, url2])
+            record = mock_record(landing_url: [url1, url2])
 
-            expect(@c.attribute(@record, :landing_url, link: true)).to eq %(<p><strong>Landing_url: </strong>#{@c.link_to url1, url1}, #{@c.link_to url2, url2}</p>)
+            expect(controller.attribute(record, :landing_url, link: true)).to eq %(<p><strong>Landing_url: </strong>#{controller.link_to url1, url1}, #{controller.link_to url2, url2}</p>)
           end
 
           it 'truncates the sum of all elements in the array' do
-            @record = mock_record(description: ['This is a lengthy description', 'Some other stuff'])
+            record = mock_record(description: ['This is a lengthy description', 'Some other stuff'])
 
-            expect(@c.attribute(@record, :description, limit: 40, label: false)).to eq '<p>This is a lengthy description, Some o...</p>'
+            expect(controller.attribute(record, :description, limit: 40, label: false)).to eq '<p>This is a lengthy description, Some o...</p>'
           end
 
           it 'converts it to a URL with the url pattern in :link and replaces the value for each value' do
-            expect(@c.attribute(@record, :category, link: '/records?i[category]={{value}}')).to eq %(<p><strong>Category: </strong>#{@c.link_to 'Images', '/records?i[category]=Images'}, #{@c.link_to 'Videos', '/records?i[category]=Videos'}</p>)
+            expect(controller.attribute(record, :category, link: '/records?i[category]={{value}}')).to eq %(<p><strong>Category: </strong>#{controller.link_to 'Images', '/records?i[category]=Images'}, #{controller.link_to 'Videos', '/records?i[category]=Videos'}</p>)
           end
         end
 
         context 'multiple attributes' do
-          before(:each) do
-            @record = mock_record(category: %w[Images Videos], creator: 'Federico', object_url: nil, source: nil)
-          end
+          let(:record) { mock_record(category: %w[Images Videos], creator: 'Federico', object_url: nil, source: nil) }
 
           it 'fetches values from multiple attributes' do
-            expect(@c.attribute(@record, %i[category creator])).to eq %(<p><strong>Category: </strong>Images, Videos, Federico</p>)
+            expect(controller.attribute(record, %i[category creator])).to eq %(<p><strong>Category: </strong>Images, Videos, Federico</p>)
           end
 
           it 'returns nothing when both values are nil' do
-            expect(@c.attribute(@record, %i[object_url source], link: true)).to be nil
+            expect(controller.attribute(record, %i[object_url source], link: true)).to be nil
           end
         end
       end
 
       describe '#attribute_link_replacement' do
         it 'generates a link and replaces the value' do
-          expect(@c.attribute_link_replacement('Images', '/records?i[category]={{value}}')).to eq(@c.link_to('Images', '/records?i[category]=Images'))
+          expect(controller.attribute_link_replacement('Images', '/records?i[category]={{value}}')).to eq(controller.link_to('Images', '/records?i[category]=Images'))
         end
 
         it 'generates a link with the value as text and url' do
-          expect(@c.attribute_link_replacement('http://google.comm/images', true)).to eq(@c.link_to('http://google.comm/images', 'http://google.comm/images'))
+          expect(controller.attribute_link_replacement('http://google.comm/images', true)).to eq(controller.link_to('http://google.comm/images', 'http://google.comm/images'))
         end
 
         it 'decodes the link_pattern' do
-          expect(@c.attribute_link_replacement('Images', '/records?i[category]=%7B%7Bvalue%7D%7D')).to eq(@c.link_to('Images', '/records?i[category]=Images'))
+          expect(controller.attribute_link_replacement('Images', '/records?i[category]=%7B%7Bvalue%7D%7D')).to eq(controller.link_to('Images', '/records?i[category]=Images'))
         end
       end
 
       describe '#next_previous_links' do
-        before(:each) do
-          @previous_record = mock_record(record_id: 1234)
-          @next_record = mock_record(record_id: 5678)
-          @record = mock_record(record_id: 1_234_567, previous_record: @previous_record, next_record: @next_record)
-          allow(@c).to receive(:params) { { search: { text: 'cat' } } }
-        end
+        let(:previous_record) { mock_record(record_id: 1234) }
+        let(:next_record)     { mock_record(record_id: 5678) }
+        let(:record)          { mock_record(record_id: 1_234_567, previous_record: previous_record, next_record: next_record) }
+
+        before { allow(controller).to receive(:params) { { search: { text: 'cat' } } } }
 
         it 'returns empty when there is no search query' do
-          allow(@c).to receive(:params) { {} }
+          allow(controller).to receive(:params) { {} }
 
-          expect(@c.next_previous_links(@record)).to eq ''
+          expect(controller.next_previous_links(record)).to eq ''
         end
 
         it 'displays the next and previous links' do
-          allow(@c).to receive(:previous_record_link) { '<a class="prev" href="/records/37674826?search%5Bpath%5D=items&amp;search%5Btext%5D=Forest+fire">Previous result</a>' }
-          allow(@c).to receive(:next_record_link) { '<a class="next" href="/records/37674826?search%5Bpath%5D=items&amp;search%5Btext%5D=Forest+fire">Next result</a>' }
+          allow(controller).to receive(:previous_record_link) { '<a class="prev" href="/records/37674826?search%5Bpath%5D=items&amp;search%5Btext%5D=Forest+fire">Previous result</a>' }
+          allow(controller).to receive(:next_record_link) { '<a class="next" href="/records/37674826?search%5Bpath%5D=items&amp;search%5Btext%5D=Forest+fire">Next result</a>' }
 
-          expect(@c.next_previous_links(@record)).to eq %(<span class=\"nav\">&lt;a class=&quot;next&quot; href=&quot;/records/37674826?search%5Bpath%5D=items&amp;amp;search%5Btext%5D=Forest+fire&quot;&gt;Next result&lt;/a&gt;</span>)
+          expect(controller.next_previous_links(record)).to eq %(<span class=\"nav\">&lt;a class=&quot;next&quot; href=&quot;/records/37674826?search%5Bpath%5D=items&amp;amp;search%5Btext%5D=Forest+fire&quot;&gt;Next result&lt;/a&gt;</span>)
         end
       end
     end

--- a/spec/supplejack/facet_spec.rb
+++ b/spec/supplejack/facet_spec.rb
@@ -5,36 +5,36 @@ require 'spec_helper'
 module Supplejack
   describe Facet do
     it 'initializes the facet with a name' do
-      facet = Supplejack::Facet.new('description', {})
+      facet = described_class.new('description', {})
 
       expect(facet.name).to eq('description')
     end
 
     it 'initializes the facet with values' do
-      facet = Supplejack::Facet.new('location', 'Wellington' => 100, 'Auckland' => 10)
+      facet = described_class.new('location', 'Wellington' => 100, 'Auckland' => 10)
 
       expect(facet.values).to eq('Wellington' => 100, 'Auckland' => 10)
     end
 
-    context 'sorting' do
-      let(:facet) { Supplejack::Facet.new('location', 'Wellington' => 100, 'Auckland' => 10, 'Dunedin' => 5, 'Queenstown' => 30) }
+    context 'when sorting' do
+      let(:facet) { described_class.new('location', 'Wellington' => 100, 'Auckland' => 10, 'Dunedin' => 5, 'Queenstown' => 30) }
 
       it 'sorts by alphabetical order set in config' do
-        allow(Supplejack).to receive(:facets_sort) { :index }
+        allow(Supplejack).to receive(:facets_sort).and_return(:index)
 
         expect(facet.values.keys).to eq %w[Auckland Dunedin Queenstown Wellington]
         expect(facet.values.values).to eq [10, 5, 30, 100]
       end
 
       it 'sorts by count set in the config' do
-        allow(Supplejack).to receive(:facets_sort) { :count }
+        allow(Supplejack).to receive(:facets_sort).and_return(:count)
 
         expect(facet.values.keys).to eq %w[Wellington Queenstown Auckland Dunedin]
         expect(facet.values.values).to eq [100, 30, 10, 5]
       end
 
       it 'overrides the global facets sort' do
-        allow(Supplejack).to receive(:facets_sort) { :count }
+        allow(Supplejack).to receive(:facets_sort).and_return(:count)
 
         expect(facet.values(:index).keys).to eq %w[Auckland Dunedin Queenstown Wellington]
       end

--- a/spec/supplejack/facet_spec.rb
+++ b/spec/supplejack/facet_spec.rb
@@ -6,32 +6,37 @@ module Supplejack
   describe Facet do
     it 'initializes the facet with a name' do
       facet = Supplejack::Facet.new('description', {})
-      facet.name.should eq('description')
+
+      expect(facet.name).to eq('description')
     end
 
     it 'initializes the facet with values' do
       facet = Supplejack::Facet.new('location', 'Wellington' => 100, 'Auckland' => 10)
-      facet.values.should eq('Wellington' => 100, 'Auckland' => 10)
+      
+      expect(facet.values).to eq('Wellington' => 100, 'Auckland' => 10)
     end
 
     context 'sorting' do
       let(:facet) { Supplejack::Facet.new('location', 'Wellington' => 100, 'Auckland' => 10, 'Dunedin' => 5, 'Queenstown' => 30) }
 
       it 'sorts by alphabetical order set in config' do
-        Supplejack.stub(:facets_sort) { :index }
-        facet.values.keys.should eq %w[Auckland Dunedin Queenstown Wellington]
-        facet.values.values.should eq [10, 5, 30, 100]
+        allow(Supplejack).to receive(:facets_sort) { :index }
+
+        expect(facet.values.keys).to eq %w[Auckland Dunedin Queenstown Wellington]
+        expect(facet.values.values).to eq [10, 5, 30, 100]
       end
 
       it 'sorts by count set in the config' do
-        Supplejack.stub(:facets_sort) { :count }
-        facet.values.keys.should eq %w[Wellington Queenstown Auckland Dunedin]
-        facet.values.values.should eq [100, 30, 10, 5]
+        allow(Supplejack).to receive(:facets_sort) { :count }
+
+        expect(facet.values.keys).to eq %w[Wellington Queenstown Auckland Dunedin]
+        expect(facet.values.values).to eq [100, 30, 10, 5]
       end
 
       it 'overrides the global facets sort' do
-        Supplejack.stub(:facets_sort) { :count }
-        facet.values(:index).keys.should eq %w[Auckland Dunedin Queenstown Wellington]
+        allow(Supplejack).to receive(:facets_sort) { :count }
+
+        expect(facet.values(:index).keys).to eq %w[Auckland Dunedin Queenstown Wellington]
       end
     end
   end

--- a/spec/supplejack/facet_spec.rb
+++ b/spec/supplejack/facet_spec.rb
@@ -12,7 +12,7 @@ module Supplejack
 
     it 'initializes the facet with values' do
       facet = Supplejack::Facet.new('location', 'Wellington' => 100, 'Auckland' => 10)
-      
+
       expect(facet.values).to eq('Wellington' => 100, 'Auckland' => 10)
     end
 

--- a/spec/supplejack/item_relation_spec.rb
+++ b/spec/supplejack/item_relation_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module Supplejack
   describe ItemRelation do
     let(:supplejack_set) { Supplejack::UserSet.new(id: '1234567890', records: [{ record_id: 1, position: 1 }]) }
-    let(:relation) { Supplejack::ItemRelation.new(supplejack_set) }
+    let(:relation) { described_class.new(supplejack_set) }
 
     describe '#initialize' do
       it 'assigns the user_set object as @user_set' do
@@ -17,7 +17,7 @@ module Supplejack
       end
 
       it 'returns an empty array of items when the user_set attributes records are nil' do
-        allow(supplejack_set).to receive(:attributes) { {} }
+        allow(supplejack_set).to receive(:attributes).and_return({})
 
         expect(relation.items).to be_empty
       end
@@ -68,7 +68,7 @@ module Supplejack
       end
 
       it 'adds the user_set api_key' do
-        allow(relation).to receive(:user_set) { double(:user_set, api_key: '1234').as_null_object }
+        allow(relation).to receive(:user_set) { instance_double(Supplejack::UserSet, api_key: '1234').as_null_object }
         item = relation.build
 
         expect(item.api_key).to eq '1234'
@@ -76,25 +76,25 @@ module Supplejack
     end
 
     describe '#create' do
-      let(:item) { double(:item).as_null_object }
+      let(:item) { instance_double(Supplejack::UserSet).as_null_object }
 
       it 'builds and saves the item' do
-        expect(relation).to receive(:build) { item }
+        allow(relation).to receive(:build).and_return(item)
         expect(item).to receive(:save)
 
         relation.create
       end
 
       it 'passes the parameters along to the build method' do
-        expect(relation).to receive(:build).with(record_id: 8, position: 3) { item }
+        allow(relation).to receive(:build).with(record_id: 8, position: 3).and_return(item)
 
         relation.create(record_id: 8, position: 3)
       end
     end
 
-    context 'items array behaviour' do
+    context 'when items behaves as array' do
       it 'executes array methods on the @items array' do
-        relation = Supplejack::ItemRelation.new(supplejack_set)
+        relation = described_class.new(supplejack_set)
         items = relation.instance_variable_get('@items')
 
         expect(items).to receive(:size)
@@ -102,13 +102,10 @@ module Supplejack
         relation.size
       end
 
-      it 'should be able to iterate through the items relation' do
-        relation = Supplejack::ItemRelation.new(supplejack_set)
+      it 'iterates through the items relation' do
+        relation = described_class.new(supplejack_set)
 
-        relation.each do |item|
-          expect(item).to be_a Supplejack::Item
-        end
-
+        expect(relation).to all(be_a Supplejack::Item)
         expect(relation.size).to eq 1
       end
     end

--- a/spec/supplejack/item_relation_spec.rb
+++ b/spec/supplejack/item_relation_spec.rb
@@ -9,64 +9,69 @@ module Supplejack
 
     describe '#initialize' do
       it 'assigns the user_set object as @user_set' do
-        Supplejack::ItemRelation.new(supplejack_set).user_set.should eq supplejack_set
+        expect(relation.user_set).to eq supplejack_set
       end
 
       it 'initializes an array of Supplejack::Items' do
-        Supplejack::ItemRelation.new(supplejack_set).items.should be_a Array
+        expect(relation.items).to be_a Array
       end
 
       it 'returns an empty array of items when the user_set attributes records are nil' do
-        supplejack_set.stub(:attributes) { {} }
-        Supplejack::ItemRelation.new(supplejack_set).items.should be_empty
+        allow(supplejack_set).to receive(:attributes) { {} }
+
+        expect(relation.items).to be_empty
       end
 
       it 'adds the user_set_id to the Supplejack::Item object' do
-        Supplejack::ItemRelation.new(supplejack_set).items.first.user_set_id.should eq '1234567890'
+        expect(relation.items.first.user_set_id).to eq '1234567890'
       end
 
       it 'adds the api_key in the user_set to the Supplejack::Item' do
         supplejack_set.api_key = 'abc123'
-        Supplejack::ItemRelation.new(supplejack_set).items.first.api_key.should eq 'abc123'
+
+        expect(relation.items.first.api_key).to eq 'abc123'
       end
     end
 
     describe '#all' do
       it 'returns the array of @items' do
-        supplejack_set.items.all.should be_a Array
+        expect(supplejack_set.items.all).to be_a Array
       end
     end
 
     describe '#find' do
       it 'returns finds the item by record_id' do
         item = relation.find(1)
-        item.should be_a Supplejack::Item
-        item.record_id.should eq 1
+
+        expect(item).to be_a Supplejack::Item
+        expect(item.record_id).to eq 1
       end
 
       it 'finds the item by a string record_id' do
         item = relation.find('1')
-        item.should be_a Supplejack::Item
-        item.record_id.should eq 1
+
+        expect(item).to be_a Supplejack::Item
+        expect(item.record_id).to eq 1
       end
     end
 
     describe '#build' do
       it 'initializes a new item object with the user_set_id' do
-        item = relation.build
-        item.user_set_id.should eq '1234567890'
+        expect(relation.build.user_set_id).to eq '1234567890'
       end
 
       it 'accepts a hash of attributes' do
         item = relation.build(record_id: 2, position: 9)
-        item.record_id.should eq 2
-        item.position.should eq 9
+
+        expect(item.record_id).to eq 2
+        expect(item.position).to eq 9
       end
 
       it 'adds the user_set api_key' do
-        relation.stub(:user_set) { double(:user_set, api_key: '1234').as_null_object }
+        allow(relation).to receive(:user_set) { double(:user_set, api_key: '1234').as_null_object }
         item = relation.build
-        item.api_key.should eq '1234'
+
+        expect(item.api_key).to eq '1234'
       end
     end
 
@@ -74,13 +79,15 @@ module Supplejack
       let(:item) { double(:item).as_null_object }
 
       it 'builds and saves the item' do
-        relation.should_receive(:build) { item }
-        item.should_receive(:save)
+        expect(relation).to receive(:build) { item }
+        expect(item).to receive(:save)
+
         relation.create
       end
 
       it 'passes the parameters along to the build method' do
-        relation.should_receive(:build).with(record_id: 8, position: 3) { item }
+        expect(relation).to receive(:build).with(record_id: 8, position: 3) { item }
+
         relation.create(record_id: 8, position: 3)
       end
     end
@@ -89,16 +96,20 @@ module Supplejack
       it 'executes array methods on the @items array' do
         relation = Supplejack::ItemRelation.new(supplejack_set)
         items = relation.instance_variable_get('@items')
-        items.should_receive(:size)
+
+        expect(items).to receive(:size)
+
         relation.size
       end
 
       it 'should be able to iterate through the items relation' do
         relation = Supplejack::ItemRelation.new(supplejack_set)
+
         relation.each do |item|
-          item.should be_a Supplejack::Item
+          expect(item).to be_a Supplejack::Item
         end
-        relation.size.should eq 1
+
+        expect(relation.size).to eq 1
       end
     end
   end

--- a/spec/supplejack/item_spec.rb
+++ b/spec/supplejack/item_spec.rb
@@ -33,7 +33,7 @@ module Supplejack
 
       it 'triggers a post request to create a set_item with the set api_key' do
         expect(item).to receive(:post).with('/sets/1234/records', { api_key: 'abc' }, record: { record_id: 1 })
-        
+
         expect(item.save).to be true
       end
 
@@ -64,7 +64,7 @@ module Supplejack
 
       it 'triggers a delete request with the user_set api_key' do
         expect(item).to receive(:delete).with('/sets/1234/records/5', api_key: 'abc')
-        
+
         item.destroy
       end
 

--- a/spec/supplejack/item_spec.rb
+++ b/spec/supplejack/item_spec.rb
@@ -5,32 +5,26 @@ require 'spec_helper'
 module Supplejack
   describe Item do
     describe '#initialize' do
-      it 'accepts a hash of attributes' do
-        Supplejack::Item.new(record_id: '123', name: 'Dog')
-      end
-
       it 'accepts a hash with string keys' do
-        Supplejack::Item.new('record_id' => '123').record_id.should eq '123'
+        expect(Supplejack::Item.new('record_id' => '123').record_id).to eq '123'
       end
 
       it 'handles nil attributes' do
-        Supplejack::Item.new(nil).record_id.should be_nil
+        expect(Supplejack::Item.new(nil).record_id).to be_nil
       end
 
-      [:record_id].each do |attribute|
-        it 'should initialize the attribute # {attribute}' do
-          Supplejack::Item.new(attribute => 'value').send(attribute).should eq 'value'
-        end
+      it 'should initialize the attribute :record_id' do
+        expect(Supplejack::Item.new(record_id: 'value').send(:record_id)).to eq 'value'
       end
     end
 
     describe '#attributes' do
       it 'should not include the api_key' do
-        Supplejack::Item.new(api_key: '1234').attributes.should_not have_key(:api_key)
+        expect(Supplejack::Item.new(api_key: '1234').attributes).not_to have_key(:api_key)
       end
 
       it 'should not include the user_set_id' do
-        Supplejack::Item.new(user_set_id: '1234').attributes.should_not have_key(:user_set_id)
+        expect(Supplejack::Item.new(user_set_id: '1234').attributes).not_to have_key(:user_set_id)
       end
     end
 
@@ -38,28 +32,29 @@ module Supplejack
       let(:item) { Supplejack::Item.new(record_id: 1, title: 'Dogs', user_set_id: '1234', api_key: 'abc') }
 
       it 'triggers a post request to create a set_item with the set api_key' do
-        item.should_receive(:post).with('/sets/1234/records', { api_key: 'abc' }, record: { record_id: 1 })
-        item.save.should be_truthy
+        expect(item).to receive(:post).with('/sets/1234/records', { api_key: 'abc' }, record: { record_id: 1 })
+        
+        expect(item.save).to be true
       end
 
       it 'sends the position when set' do
-        item.should_receive(:post).with('/sets/1234/records', { api_key: 'abc' }, record: { record_id: 1, position: 3 })
+        expect(item).to receive(:post).with('/sets/1234/records', { api_key: 'abc' }, record: { record_id: 1, position: 3 })
         item.position = 3
-        item.save.should be_truthy
+
+        expect(item.save).to be true
       end
 
       context 'HTTP error is raised' do
-        before :each do
-          item.stub(:post).and_raise(RestClient::Forbidden.new)
-        end
+        before { allow(item).to receive(:post).and_raise(RestClient::Forbidden.new) }
 
         it 'returns false when a HTTP error is raised' do
-          item.save.should be_falsey
+          expect(item.save).to be false
         end
 
         it 'stores the error when a error is raised' do
           item.save
-          item.errors.should eq 'Forbidden'
+
+          expect(item.errors).to eq 'Forbidden'
         end
       end
     end
@@ -68,22 +63,22 @@ module Supplejack
       let(:item) { Supplejack::Item.new(user_set_id: '1234', api_key: 'abc', record_id: 5) }
 
       it 'triggers a delete request with the user_set api_key' do
-        item.should_receive(:delete).with('/sets/1234/records/5', api_key: 'abc')
+        expect(item).to receive(:delete).with('/sets/1234/records/5', api_key: 'abc')
+        
         item.destroy
       end
 
       context 'HTTP error is raised' do
-        before :each do
-          item.stub(:delete).and_raise(RestClient::Forbidden.new)
-        end
+        before { allow(item).to receive(:delete).and_raise(RestClient::Forbidden.new) }
 
         it 'returns false when a HTTP error is raised' do
-          item.destroy.should be_falsey
+          expect(item.destroy).to be false
         end
 
         it 'stores the error when a error is raised' do
           item.destroy
-          item.errors.should eq 'Forbidden'
+
+          expect(item.errors).to eq 'Forbidden'
         end
       end
     end
@@ -91,18 +86,20 @@ module Supplejack
     describe '#date' do
       it 'returns a Time object' do
         item = Supplejack::Item.new(date: ['1977-01-01T00:00:00.000Z'])
-        item.date.should eq Time.parse('1977-01-01T00:00:00.000Z')
+
+        expect(item.date).to eq Time.parse('1977-01-01T00:00:00.000Z')
       end
 
       it 'returns nil when the date is not in the correct format' do
         item = Supplejack::Item.new(date: ['afsdfgsdfg'])
-        item.date.should be_nil
+
+        expect(item.date).to be nil
       end
     end
 
     describe '#method_missing' do
       it 'returns nil for any unknown attribute' do
-        Supplejack::Item.new.non_existent_method.should be_nil
+        expect(Supplejack::Item.new.non_existent_method).to be nil
       end
     end
   end

--- a/spec/supplejack/item_spec.rb
+++ b/spec/supplejack/item_spec.rb
@@ -6,30 +6,30 @@ module Supplejack
   describe Item do
     describe '#initialize' do
       it 'accepts a hash with string keys' do
-        expect(Supplejack::Item.new('record_id' => '123').record_id).to eq '123'
+        expect(described_class.new('record_id' => '123').record_id).to eq '123'
       end
 
       it 'handles nil attributes' do
-        expect(Supplejack::Item.new(nil).record_id).to be_nil
+        expect(described_class.new(nil).record_id).to be_nil
       end
 
-      it 'should initialize the attribute :record_id' do
-        expect(Supplejack::Item.new(record_id: 'value').send(:record_id)).to eq 'value'
+      it 'initializes the attribute :record_id' do
+        expect(described_class.new(record_id: 'value').send(:record_id)).to eq 'value'
       end
     end
 
     describe '#attributes' do
-      it 'should not include the api_key' do
-        expect(Supplejack::Item.new(api_key: '1234').attributes).not_to have_key(:api_key)
+      it 'excludes the api_key' do
+        expect(described_class.new(api_key: '1234').attributes).not_to have_key(:api_key)
       end
 
-      it 'should not include the user_set_id' do
-        expect(Supplejack::Item.new(user_set_id: '1234').attributes).not_to have_key(:user_set_id)
+      it 'excludes the user_set_id' do
+        expect(described_class.new(user_set_id: '1234').attributes).not_to have_key(:user_set_id)
       end
     end
 
     describe '#save' do
-      let(:item) { Supplejack::Item.new(record_id: 1, title: 'Dogs', user_set_id: '1234', api_key: 'abc') }
+      let(:item) { described_class.new(record_id: 1, title: 'Dogs', user_set_id: '1234', api_key: 'abc') }
 
       it 'triggers a post request to create a set_item with the set api_key' do
         expect(item).to receive(:post).with('/sets/1234/records', { api_key: 'abc' }, record: { record_id: 1 })
@@ -44,7 +44,7 @@ module Supplejack
         expect(item.save).to be true
       end
 
-      context 'HTTP error is raised' do
+      context 'when HTTP error is raised' do
         before { allow(item).to receive(:post).and_raise(RestClient::Forbidden.new) }
 
         it 'returns false when a HTTP error is raised' do
@@ -60,7 +60,7 @@ module Supplejack
     end
 
     describe '#destroy' do
-      let(:item) { Supplejack::Item.new(user_set_id: '1234', api_key: 'abc', record_id: 5) }
+      let(:item) { described_class.new(user_set_id: '1234', api_key: 'abc', record_id: 5) }
 
       it 'triggers a delete request with the user_set api_key' do
         expect(item).to receive(:delete).with('/sets/1234/records/5', api_key: 'abc')
@@ -68,7 +68,7 @@ module Supplejack
         item.destroy
       end
 
-      context 'HTTP error is raised' do
+      context 'when HTTP error is raised' do
         before { allow(item).to receive(:delete).and_raise(RestClient::Forbidden.new) }
 
         it 'returns false when a HTTP error is raised' do
@@ -85,13 +85,13 @@ module Supplejack
 
     describe '#date' do
       it 'returns a Time object' do
-        item = Supplejack::Item.new(date: ['1977-01-01T00:00:00.000Z'])
+        item = described_class.new(date: ['1977-01-01T00:00:00.000Z'])
 
         expect(item.date).to eq Time.parse('1977-01-01T00:00:00.000Z')
       end
 
       it 'returns nil when the date is not in the correct format' do
-        item = Supplejack::Item.new(date: ['afsdfgsdfg'])
+        item = described_class.new(date: ['afsdfgsdfg'])
 
         expect(item.date).to be nil
       end
@@ -99,7 +99,7 @@ module Supplejack
 
     describe '#method_missing' do
       it 'returns nil for any unknown attribute' do
-        expect(Supplejack::Item.new.non_existent_method).to be nil
+        expect(described_class.new.non_existent_method).to be nil
       end
     end
   end

--- a/spec/supplejack/log_subscriber_spec.rb
+++ b/spec/supplejack/log_subscriber_spec.rb
@@ -7,7 +7,7 @@ module Supplejack
     it 'returns nil when logging not enabled' do
       allow(Supplejack).to receive(:enable_logging).and_return(false)
 
-      expect(Supplejack::LogSubscriber.new.log_request(1, {})).to be nil
+      expect(described_class.new.log_request(1, {})).to be nil
     end
   end
 end

--- a/spec/supplejack/log_subscriber_spec.rb
+++ b/spec/supplejack/log_subscriber_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 module Supplejack
   describe LogSubscriber do
     it 'returns nil when logging not enabled' do
-      Supplejack.stub(:enable_logging) { false }
+      allow(Supplejack).to receive(:enable_logging).and_return(false)
 
-      Supplejack::LogSubscriber.new.log_request(1, {}).should be_nil
+      expect(Supplejack::LogSubscriber.new.log_request(1, {})).to be nil
     end
   end
 end

--- a/spec/supplejack/more_like_this_record_spec.rb
+++ b/spec/supplejack/more_like_this_record_spec.rb
@@ -37,7 +37,7 @@ module Supplejack
 
       it 'requests more_like_this api with params' do
         expect(more_like_this).to receive(:get).with('/records/101/more_like_this', { frequency: 2, mlt_fields: 'title,description' }).and_return('record' => {})
-        
+
         more_like_this.records
       end
 

--- a/spec/supplejack/more_like_this_record_spec.rb
+++ b/spec/supplejack/more_like_this_record_spec.rb
@@ -36,12 +36,13 @@ module Supplejack
       let(:more_like_this) { Supplejack::MoreLikeThisRecord.new(101, { frequency: 2, mlt_fields: %i[title description] }) }
 
       it 'requests more_like_this api with params' do
-        more_like_this.should_receive(:get).with('/records/101/more_like_this', { frequency: 2, mlt_fields: 'title,description' }).and_return('record' => {})
+        expect(more_like_this).to receive(:get).with('/records/101/more_like_this', { frequency: 2, mlt_fields: 'title,description' }).and_return('record' => {})
+        
         more_like_this.records
       end
 
       context 'when record not found' do
-        before { more_like_this.stub(:get).and_raise(RestClient::ResourceNotFound) }
+        before { allow(more_like_this).to receive(:get).and_raise(RestClient::ResourceNotFound) }
 
         it 'raises an error' do
           expect { more_like_this.records }.to raise_error(Supplejack::RecordNotFound)
@@ -49,7 +50,7 @@ module Supplejack
       end
 
       context 'when there is standard error on API call' do
-        before { more_like_this.stub(:get).and_raise(StandardError) }
+        before { allow(more_like_this).to receive(:get).and_raise(StandardError) }
 
         it 'returns an empty array' do
           expect(more_like_this.records).to eq []

--- a/spec/supplejack/more_like_this_record_spec.rb
+++ b/spec/supplejack/more_like_this_record_spec.rb
@@ -7,12 +7,12 @@ module Supplejack
     describe '#initialize' do
       context 'with non integer record_id' do
         it 'raises Supplejack::MalformedRequest error' do
-          expect { Supplejack::MoreLikeThisRecord.new('notvalidid') }.to raise_error(Supplejack::MalformedRequest)
+          expect { described_class.new('notvalidid') }.to raise_error(Supplejack::MalformedRequest)
         end
       end
 
       context 'with valid id and no options' do
-        let(:more_like_this) { Supplejack::MoreLikeThisRecord.new(101) }
+        let(:more_like_this) { described_class.new(101) }
 
         it 'has default params' do
           expect(more_like_this.params).to eq({ frequency: 1 })
@@ -24,7 +24,7 @@ module Supplejack
       end
 
       context 'with valid id and options' do
-        let(:more_like_this) { Supplejack::MoreLikeThisRecord.new(1, { frequency: 2, mlt_fields: %i[title description] }) }
+        let(:more_like_this) { described_class.new(1, { frequency: 2, mlt_fields: %i[title description] }) }
 
         it 'has default params' do
           expect(more_like_this.params).to eq({ frequency: 2, mlt_fields: 'title,description' })
@@ -33,10 +33,10 @@ module Supplejack
     end
 
     describe '#records' do
-      let(:more_like_this) { Supplejack::MoreLikeThisRecord.new(101, { frequency: 2, mlt_fields: %i[title description] }) }
+      let(:more_like_this) { described_class.new(101, { frequency: 2, mlt_fields: %i[title description] }) }
 
       it 'requests more_like_this api with params' do
-        expect(more_like_this).to receive(:get).with('/records/101/more_like_this', { frequency: 2, mlt_fields: 'title,description' }).and_return('record' => {})
+        allow(more_like_this).to receive(:get).with('/records/101/more_like_this', { frequency: 2, mlt_fields: 'title,description' }).and_return('record' => {})
 
         more_like_this.records
       end

--- a/spec/supplejack/paginated_collection_spec.rb
+++ b/spec/supplejack/paginated_collection_spec.rb
@@ -3,38 +3,38 @@
 require 'spec_helper'
 
 describe 'PaginatedCollection' do
-  subject { Supplejack::PaginatedCollection.new [], 1, 10, 20 }
+  subject(:collection) { Supplejack::PaginatedCollection.new [], 1, 10, 20 }
 
-  it { expect(subject).to be_an Array }
+  it { expect(collection).to be_an Array }
 
-  context 'behaves like a WillPaginate::Collection' do
-    it { expect(subject.total_entries).to eq 20 }
-    it { expect(subject.total_pages).to eq 2 }
-    it { expect(subject.current_page).to eq 1 }
-    it { expect(subject.per_page).to eq 10 }
-    it { expect(subject.previous_page).to be nil }
-    it { expect(subject.next_page).to eq 2 }
-    it { expect(subject.out_of_bounds?).not_to be true }
-    it { expect(subject.offset).to eq 0 }
+  context 'when behaves like a WillPaginate::Collection' do
+    it { expect(collection.total_entries).to eq 20 }
+    it { expect(collection.total_pages).to eq 2 }
+    it { expect(collection.current_page).to eq 1 }
+    it { expect(collection.per_page).to eq 10 }
+    it { expect(collection.previous_page).to be nil }
+    it { expect(collection.next_page).to eq 2 }
+    it { expect(collection.out_of_bounds?).not_to be true }
+    it { expect(collection.offset).to eq 0 }
 
-    it 'should allow setting total_count' do
-      subject.total_count = 1
+    it 'allows setting total_count' do
+      collection.total_count = 1
 
-      expect(subject.total_count).to eq 1
+      expect(collection.total_count).to eq 1
     end
 
-    it 'should allow setting total_entries' do
-      subject.total_entries = 1
+    it 'allows setting total_entries' do
+      collection.total_entries = 1
 
-      expect(subject.total_entries).to eq 1
+      expect(collection.total_entries).to eq 1
     end
   end
 
-  context 'behaves like Kaminari' do
-    it { expect(subject.total_count).to eq 20 }
-    it { expect(subject.num_pages).to eq 2 }
-    it { expect(subject.limit_value).to eq 10 }
-    it { expect(subject.first_page?).to be true }
-    it { expect(subject.last_page?).not_to be true }
+  context 'when behaves like Kaminari' do
+    it { expect(collection.total_count).to eq 20 }
+    it { expect(collection.num_pages).to eq 2 }
+    it { expect(collection.limit_value).to eq 10 }
+    it { expect(collection.first_page?).to be true }
+    it { expect(collection.last_page?).not_to be true }
   end
 end

--- a/spec/supplejack/paginated_collection_spec.rb
+++ b/spec/supplejack/paginated_collection_spec.rb
@@ -5,34 +5,36 @@ require 'spec_helper'
 describe 'PaginatedCollection' do
   subject { Supplejack::PaginatedCollection.new [], 1, 10, 20 }
 
-  it { subject.should be_an(Array) }
+  it { expect(subject).to be_an Array }
 
   context 'behaves like a WillPaginate::Collection' do
-    it { subject.total_entries.should eql(20) }
-    it { subject.total_pages.should eql(2) }
-    it { subject.current_page.should eql(1) }
-    it { subject.per_page.should eql(10) }
-    it { subject.previous_page.should be_nil }
-    it { subject.next_page.should eql(2) }
-    it { subject.out_of_bounds?.should_not be_truthy }
-    it { subject.offset.should eql(0) }
+    it { expect(subject.total_entries).to eq 20 }
+    it { expect(subject.total_pages).to eq 2 }
+    it { expect(subject.current_page).to eq 1 }
+    it { expect(subject.per_page).to eq 10 }
+    it { expect(subject.previous_page).to be nil }
+    it { expect(subject.next_page).to eq 2 }
+    it { expect(subject.out_of_bounds?).not_to be true }
+    it { expect(subject.offset).to eq 0 }
 
     it 'should allow setting total_count' do
       subject.total_count = 1
-      subject.total_count.should eql(1)
+
+      expect(subject.total_count).to eq 1
     end
 
     it 'should allow setting total_entries' do
       subject.total_entries = 1
-      subject.total_entries.should eql(1)
+
+      expect(subject.total_entries).to eq 1
     end
   end
 
   context 'behaves like Kaminari' do
-    it { subject.total_count.should eql(20) }
-    it { subject.num_pages.should eql(2) }
-    it { subject.limit_value.should eql(10) }
-    it { subject.first_page?.should be_truthy }
-    it { subject.last_page?.should_not be_truthy }
+    it { expect(subject.total_count).to eq 20 }
+    it { expect(subject.num_pages).to eq 2 }
+    it { expect(subject.limit_value).to eq 10 }
+    it { expect(subject.first_page?).to be true }
+    it { expect(subject.last_page?).not_to be true }
   end
 end

--- a/spec/supplejack/record_spec.rb
+++ b/spec/supplejack/record_spec.rb
@@ -146,7 +146,7 @@ module Supplejack
     end
 
     describe '#single_value_methods' do
-      before(:each) { Supplejack.single_value_methods = [:description] }
+      before { Supplejack.single_value_methods = [:description] }
 
       it 'converts values defined in the single_value_methods to a string' do
         record = SupplejackRecord.new('description' => %w[One Two])
@@ -219,13 +219,13 @@ module Supplejack
         end
 
         context '#using a special search klass' do
-          before(:each) { @search = ::Search.new }
+          let(:search) { ::Search.new }
 
           it 'uses the specified search klass' do
             allow(SupplejackRecord).to receive(:get) { { 'record' => {} } }
             allow(Supplejack).to receive(:search_klass) { 'Search' }
 
-            expect(::Search).to receive(:new).with(i: { location: 'Wellington' }).and_return(@search)
+            expect(::Search).to receive(:new).with(i: { location: 'Wellington' }).and_return(search)
             SupplejackRecord.find(1, i: { location: 'Wellington' })
           end
 
@@ -233,7 +233,7 @@ module Supplejack
             allow(SupplejackRecord).to receive(:get) { { 'record' => {} } }
             allow(Supplejack).to receive(:search_klass) { nil }
 
-            expect(Supplejack::Search).to receive(:new).with(i: { location: 'Wellington' }).and_return(@search)
+            expect(Supplejack::Search).to receive(:new).with(i: { location: 'Wellington' }).and_return(search)
             SupplejackRecord.find(1, i: { location: 'Wellington' })
           end
 

--- a/spec/supplejack/record_spec.rb
+++ b/spec/supplejack/record_spec.rb
@@ -24,22 +24,26 @@ module Supplejack
   describe Record do
     it 'initializes its attributes from a JSON string' do
       record = SupplejackRecord.new(%({"type": "Person", "location": "NZ"}))
-      record.attributes.should eq(type: 'Person', location: 'NZ')
+      
+      expect(record.attributes).to eq(type: 'Person', location: 'NZ')
     end
 
     it 'handles nil params' do
       record = SupplejackRecord.new(nil)
-      record.attributes.should eq({})
+      
+      expect(record.attributes).to eq({})
     end
 
     it 'handles a string as params' do
       record = SupplejackRecord.new('')
-      record.attributes.should eq({})
+      
+      expect(record.attributes).to eq({})
     end
 
     it 'handles a array as params' do
       record = SupplejackRecord.new([])
-      record.attributes.should eq({})
+      
+      expect(record.attributes).to eq({})
     end
 
     it 'raises a NoMethodError for every method call that doesn\'t have a key in the attributes' do
@@ -49,100 +53,111 @@ module Supplejack
 
     it 'should return the value when is present in the attributes' do
       record = SupplejackRecord.new(weird_method: 'Something')
-      record.weird_method.should eq 'Something'
+      
+      expect(record.weird_method).to eq 'Something'
     end
 
     describe 'id' do
       it 'returns the record_id' do
         record = SupplejackRecord.new('record_id' => '95')
-        record.id.should eq 95
+        
+        expect(record.id).to eq 95
       end
 
       it 'returns the id' do
         record = SupplejackRecord.new('id' => '96')
-        record.id.should eq 96
+        
+        expect(record.id).to eq 96
       end
     end
 
     describe '#title' do
       it 'returns the title attribute value' do
-        SupplejackRecord.new(title: 'Dogs').title.should eq 'Dogs'
+        expect(SupplejackRecord.new(title: 'Dogs').title).to eq 'Dogs'
       end
 
       it 'returns "Untitled" for records without a title' do
-        SupplejackRecord.new(title: nil).title.should eq 'Untitled'
+        expect(SupplejackRecord.new(title: nil).title).to eq 'Untitled'
       end
     end
 
     describe '#metadata' do
       it 'returns an array of hashes with special fields their values and schemas' do
-        Supplejack.stub(:special_fields) { { admin: { fields: [:location] } } }
+        allow(Supplejack).to receive(:special_fields) { { admin: { fields: [:location] } } }
+
         record = SupplejackRecord.new(location: 'Wellington')
-        record.metadata.should include(name: 'location', schema: 'admin', value: 'Wellington')
+        expect(record.metadata).to include(name: 'location', schema: 'admin', value: 'Wellington')
       end
 
       it 'returns an array of hashes with special fields their values and schemas for multiple special_fields configured' do
-        Supplejack.stub(:special_fields) { { admin: { fields: [:location] }, supplejack_user: { fields: [:description] } } }
+        allow(Supplejack).to receive(:special_fields) { { admin: { fields: [:location] }, supplejack_user: { fields: [:description] } } }
+
         record = SupplejackRecord.new(location: 'Wellington', description: 'Some description')
-        record.metadata.should include({ name: 'location', schema: 'admin', value: 'Wellington' }, name: 'description', schema: 'supplejack_user', value: 'Some description')
+        
+        expect(record.metadata).to include({ name: 'location', schema: 'admin', value: 'Wellington' }, name: 'description', schema: 'supplejack_user', value: 'Some description')
       end
 
       it 'should not return metadata for inexistent attribtues' do
-        Supplejack.stub(:supplejack_fields) { [:description] }
+        allow(Supplejack).to receive(:supplejack_fields) { [:description] }
+
         record = SupplejackRecord.new(location: 'Wellington')
-        record.metadata.should be_empty
+        expect(record.metadata.empty?).to be true
       end
 
       it 'returns multiple elements for a multi value field' do
-        Supplejack.stub(:special_fields) { { admin: { fields: [:location] } } }
+        allow(Supplejack).to receive(:special_fields) { { admin: { fields: [:location] } } }
+
         record = SupplejackRecord.new(location: %w[Wellington Auckland])
-        record.metadata.should include({ name: 'location', schema: 'admin', value: 'Wellington' }, name: 'location', schema: 'admin', value: 'Auckland')
+
+        expect(record.metadata).to include({ name: 'location', schema: 'admin', value: 'Wellington' }, name: 'location', schema: 'admin', value: 'Auckland')
       end
 
       it 'returns a empty array for a empty field' do
-        Supplejack.stub(:supplejack_fields) { [:location] }
+        allow(Supplejack).to receive(:supplejack_fields) { [:location] }
+
         record = SupplejackRecord.new(location: nil)
-        record.metadata.should be_empty
+        
+        expect(record.metadata.empty?).to be true
       end
 
       it 'works for boolean fields too' do
-        Supplejack.stub(:special_fields) { { admin: { fields: [:is_human] } } }
+        allow(Supplejack).to receive(:special_fields) { { admin: { fields: [:is_human] } } }
+
         record = SupplejackRecord.new(is_human: true)
-        record.metadata.should include(name: 'is_human', schema: 'admin', value: true)
+
+        expect(record.metadata).to include(name: 'is_human', schema: 'admin', value: true)
       end
 
-      # it 'works for boolean fields when they are true' do
-      #   Supplejack.stub(:admin_fields) { [:is_animal] }
-      #   record = SupplejackRecord.new({:is_animal => true})
-      #   record.metadata.should include({:name => 'is_animal', :schema => 'admin', :value => true})
-      # end
-
       it 'works for boolean fields when they are false' do
-        Supplejack.stub(:special_fields) { { admin: { fields: [:is_human] } } }
+        allow(Supplejack).to receive(:special_fields) { { admin: { fields: [:is_human] } } }
+
         record = SupplejackRecord.new(is_human: false)
-        record.metadata.should include(name: 'is_human', schema: 'admin', value: false)
+
+        expect(record.metadata).to include(name: 'is_human', schema: 'admin', value: false)
       end
 
       it 'returns names with the schema removed' do
-        Supplejack.stub(:special_fields) { { admin: { fields: [:admin_identifier] } } }
+        allow(Supplejack).to receive(:special_fields) { { admin: { fields: [:admin_identifier] } } }
+
         record = SupplejackRecord.new(admin_identifier: 'sj:IE1174615')
-        record.metadata.should include(name: 'identifier', schema: 'admin', value: 'sj:IE1174615')
+
+        expect(record.metadata).to include(name: 'identifier', schema: 'admin', value: 'sj:IE1174615')
       end
     end
 
     describe '#single_value_methods' do
-      before(:each) do
-        Supplejack.single_value_methods = [:description]
-      end
+      before(:each) { Supplejack.single_value_methods = [:description] }
 
       it 'converts values defined in the single_value_methods to a string' do
         record = SupplejackRecord.new('description' => %w[One Two])
-        record.description.should eq 'One'
+        
+        expect(record.description).to eq 'One'
       end
 
       it 'returns the string if is already a string' do
         record = SupplejackRecord.new('description' => 'One')
-        record.description.should eq 'One'
+        
+        expect(record.description).to eq 'One'
       end
     end
 
@@ -150,12 +165,14 @@ module Supplejack
       describe attr.to_s do
         it "returns the #{attr}" do
           record = SupplejackRecord.new(attr => 1)
-          record.send(attr).should eq 1
+          
+          expect(record.send(attr)).to eq 1
         end
 
         it 'returns the nil' do
           record = SupplejackRecord.new({})
-          record.send(attr).should be_nil
+          
+          expect(record.send(attr)).to be_nil
         end
       end
     end
@@ -163,7 +180,8 @@ module Supplejack
     describe '#find' do
       context 'single record' do
         it 'raises a Supplejack::RecordNotFound' do
-          SupplejackRecord.stub(:get).and_raise(RestClient::ResourceNotFound)
+          allow(SupplejackRecord).to receive(:get).and_raise(RestClient::ResourceNotFound)
+
           expect { SupplejackRecord.find(1) }.to raise_error(Supplejack::RecordNotFound)
         end
 
@@ -172,57 +190,64 @@ module Supplejack
         end
 
         it 'requests the record from the API' do
-          SupplejackRecord.should_receive(:get).with('/records/1', fields: 'default').and_return('record' => {})
+          expect(SupplejackRecord).to receive(:get).with('/records/1', fields: 'default').and_return('record' => {})
+          
           SupplejackRecord.find(1)
         end
 
         it 'initializes a new SupplejackRecord object' do
-          SupplejackRecord.stub(:get).and_return('record' => { 'record_id' => '1', 'title' => 'Wellington' })
+          allow(SupplejackRecord).to receive(:get).and_return('record' => { 'record_id' => '1', 'title' => 'Wellington' })
           record = SupplejackRecord.find(1)
-          record.class.should eq SupplejackRecord
-          record.id.should eq 1
-          record.title.should eq 'Wellington'
+          
+          expect(record.class).to eq SupplejackRecord
+          expect(record.id).to eq 1
+          expect(record.title).to eq 'Wellington'
         end
 
         it 'send the fields defined in the configuration' do
-          Supplejack.stub(:fields) { %i[verbose default] }
-          SupplejackRecord.should_receive(:get).with('/records/1', fields: 'verbose,default').and_return('record' => {})
+          allow(Supplejack).to receive(:fields) { %i[verbose default] }
+          
+          expect(SupplejackRecord).to receive(:get).with('/records/1', fields: 'verbose,default').and_return('record' => {})
+          
           SupplejackRecord.find(1)
         end
 
         it 'sets the correct search options' do
-          SupplejackRecord.should_receive(:get).with('/records/1', hash_including(search: hash_including(text: 'dog'))).and_return('record' => {})
+          expect(SupplejackRecord).to receive(:get).with('/records/1', hash_including(search: hash_including(text: 'dog'))).and_return('record' => {})
+
           SupplejackRecord.find(1, text: 'dog')
         end
 
         context '#using a special search klass' do
-          before(:each) do
-            @search = ::Search.new
-          end
+          before(:each) { @search = ::Search.new }
 
           it 'uses the specified search klass' do
-            SupplejackRecord.stub(:get) { { 'record' => {} } }
-            Supplejack.stub(:search_klass) { 'Search' }
-            ::Search.should_receive(:new).with(i: { location: 'Wellington' }).and_return(@search)
+            allow(SupplejackRecord).to receive(:get) { { 'record' => {} } }
+            allow(Supplejack).to receive(:search_klass) { 'Search' }
+
+            expect(::Search).to receive(:new).with(i: { location: 'Wellington' }).and_return(@search)
             SupplejackRecord.find(1, i: { location: 'Wellington' })
           end
 
           it 'uses the default search klass' do
-            SupplejackRecord.stub(:get) { { 'record' => {} } }
-            Supplejack.stub(:search_klass) { nil }
-            Supplejack::Search.should_receive(:new).with(i: { location: 'Wellington' }).and_return(@search)
+            allow(SupplejackRecord).to receive(:get) { { 'record' => {} } }
+            allow(Supplejack).to receive(:search_klass) { nil }
+
+            expect(Supplejack::Search).to receive(:new).with(i: { location: 'Wellington' }).and_return(@search)
             SupplejackRecord.find(1, i: { location: 'Wellington' })
           end
 
           it 'sends the params from the subclassed search to the API' do
-            Supplejack.stub(:search_klass) { 'Search' }
-            SupplejackRecord.should_receive(:get).with('/records/1', hash_including(search: hash_including(and: { name: 'John' }, or: { type: ['Person'] }))).and_return('record' => {})
+            allow(Supplejack).to receive(:search_klass) { 'Search' }
+
+            expect(SupplejackRecord).to receive(:get).with('/records/1', hash_including(search: hash_including(and: { name: 'John' }, or: { type: ['Person'] }))).and_return('record' => {})
             SupplejackRecord.find(1, i: { name: 'John' })
           end
 
           it 'sends any changes to the api_params made on the subclassed search object' do
-            Supplejack.stub(:search_klass) { 'SpecialSearch' }
-            SupplejackRecord.should_receive(:get).with('/records/1', hash_including(search: hash_including(and: {}))).and_return('record' => {})
+            allow(Supplejack).to receive(:search_klass) { 'SpecialSearch' }
+
+            expect(SupplejackRecord).to receive(:get).with('/records/1', hash_including(search: hash_including(and: {}))).and_return('record' => {})
             SupplejackRecord.find(1, i: { format: 'Images' })
           end
         end
@@ -230,21 +255,23 @@ module Supplejack
 
       context 'multiple records' do
         it 'sends a request to /records/multiple endpoint with an array of record ids' do
-          SupplejackRecord.should_receive(:get).with('/records/multiple', record_ids: [1, 2], fields: 'default').and_return('records' => [])
+          expect(SupplejackRecord).to receive(:get).with('/records/multiple', record_ids: [1, 2], fields: 'default').and_return('records' => [])
           SupplejackRecord.find([1, 2])
         end
 
         it 'initializes multiple SupplejackRecord objects' do
-          SupplejackRecord.stub(:get).and_return('records' => [{ 'id' => '1' }, { 'id' => '2' }])
+          allow(SupplejackRecord).to receive(:get).and_return('records' => [{ 'id' => '1' }, { 'id' => '2' }])
           records = SupplejackRecord.find([1, 2])
-          records.size.should eq 2
-          records.first.class.should eq SupplejackRecord
-          records.first.id.should eq 1
+
+          expect(records.size).to eq 2
+          expect(records.first.class).to eq SupplejackRecord
+          expect(records.first.id).to eq 1
         end
 
         it 'requests the fields in Supplejack.fields' do
-          Supplejack.stub(:fields) { %i[verbose description] }
-          SupplejackRecord.should_receive(:get).with('/records/multiple', record_ids: [1, 2], fields: 'verbose,description').and_return('records' => [])
+          allow(Supplejack).to receive(:fields) { %i[verbose description] }
+
+          expect(SupplejackRecord).to receive(:get).with('/records/multiple', record_ids: [1, 2], fields: 'verbose,description').and_return('records' => [])
           SupplejackRecord.find([1, 2])
         end
       end

--- a/spec/supplejack/record_spec.rb
+++ b/spec/supplejack/record_spec.rb
@@ -24,25 +24,25 @@ module Supplejack
   describe Record do
     it 'initializes its attributes from a JSON string' do
       record = SupplejackRecord.new(%({"type": "Person", "location": "NZ"}))
-      
+
       expect(record.attributes).to eq(type: 'Person', location: 'NZ')
     end
 
     it 'handles nil params' do
       record = SupplejackRecord.new(nil)
-      
+
       expect(record.attributes).to eq({})
     end
 
     it 'handles a string as params' do
       record = SupplejackRecord.new('')
-      
+
       expect(record.attributes).to eq({})
     end
 
     it 'handles a array as params' do
       record = SupplejackRecord.new([])
-      
+
       expect(record.attributes).to eq({})
     end
 
@@ -53,20 +53,20 @@ module Supplejack
 
     it 'should return the value when is present in the attributes' do
       record = SupplejackRecord.new(weird_method: 'Something')
-      
+
       expect(record.weird_method).to eq 'Something'
     end
 
     describe 'id' do
       it 'returns the record_id' do
         record = SupplejackRecord.new('record_id' => '95')
-        
+
         expect(record.id).to eq 95
       end
 
       it 'returns the id' do
         record = SupplejackRecord.new('id' => '96')
-        
+
         expect(record.id).to eq 96
       end
     end
@@ -93,7 +93,7 @@ module Supplejack
         allow(Supplejack).to receive(:special_fields) { { admin: { fields: [:location] }, supplejack_user: { fields: [:description] } } }
 
         record = SupplejackRecord.new(location: 'Wellington', description: 'Some description')
-        
+
         expect(record.metadata).to include({ name: 'location', schema: 'admin', value: 'Wellington' }, name: 'description', schema: 'supplejack_user', value: 'Some description')
       end
 
@@ -116,7 +116,7 @@ module Supplejack
         allow(Supplejack).to receive(:supplejack_fields) { [:location] }
 
         record = SupplejackRecord.new(location: nil)
-        
+
         expect(record.metadata.empty?).to be true
       end
 
@@ -150,13 +150,13 @@ module Supplejack
 
       it 'converts values defined in the single_value_methods to a string' do
         record = SupplejackRecord.new('description' => %w[One Two])
-        
+
         expect(record.description).to eq 'One'
       end
 
       it 'returns the string if is already a string' do
         record = SupplejackRecord.new('description' => 'One')
-        
+
         expect(record.description).to eq 'One'
       end
     end
@@ -165,13 +165,13 @@ module Supplejack
       describe attr.to_s do
         it "returns the #{attr}" do
           record = SupplejackRecord.new(attr => 1)
-          
+
           expect(record.send(attr)).to eq 1
         end
 
         it 'returns the nil' do
           record = SupplejackRecord.new({})
-          
+
           expect(record.send(attr)).to be_nil
         end
       end
@@ -191,14 +191,14 @@ module Supplejack
 
         it 'requests the record from the API' do
           expect(SupplejackRecord).to receive(:get).with('/records/1', fields: 'default').and_return('record' => {})
-          
+
           SupplejackRecord.find(1)
         end
 
         it 'initializes a new SupplejackRecord object' do
           allow(SupplejackRecord).to receive(:get).and_return('record' => { 'record_id' => '1', 'title' => 'Wellington' })
           record = SupplejackRecord.find(1)
-          
+
           expect(record.class).to eq SupplejackRecord
           expect(record.id).to eq 1
           expect(record.title).to eq 'Wellington'
@@ -206,9 +206,9 @@ module Supplejack
 
         it 'send the fields defined in the configuration' do
           allow(Supplejack).to receive(:fields) { %i[verbose default] }
-          
+
           expect(SupplejackRecord).to receive(:get).with('/records/1', fields: 'verbose,default').and_return('record' => {})
-          
+
           SupplejackRecord.find(1)
         end
 

--- a/spec/supplejack/request_spec.rb
+++ b/spec/supplejack/request_spec.rb
@@ -10,7 +10,7 @@ end
 
 module Supplejack
   describe Request do
-    let(:subject) { Supplejack::TestClass.new }
+    subject(:requester) { Supplejack::TestClass.new }
 
     before do
       allow(Supplejack).to receive(:api_key).and_return('123')
@@ -28,50 +28,52 @@ module Supplejack
                   method: :get, read_timeout: 20,
                   headers: { 'Authentication-Token': '123' })
 
-          subject.get('/records', and: { name: 'John' })
+          requester.get('/records', and: { name: 'John' })
         end
 
         it 'parses the JSON returned' do
-          expect(subject.get('/records')).to eq('search' => {})
+          expect(requester.get('/records')).to eq('search' => {})
         end
 
         it 'logs a error correctly when the response from the API failed' do
           allow(RestClient::Request).to receive(:execute).and_return(nil)
 
+          # rubocop:disable RSpec/AnyInstance
           expect_any_instance_of(Supplejack::LogSubscriber).to receive(:log_request)
+          # rubocop:enable RSpec/AnyInstance
 
-          subject.get('/records')
+          requester.get('/records')
         end
 
-        context 'request format' do
+        context 'when requesting with format' do
           it 'executes a request in a json format' do
             expect(RestClient::Request).to receive(:execute).with(hash_including(url: 'http://api.org/records.json', headers: { 'Authentication-Token': '123' }))
 
-            subject.get('/records')
+            requester.get('/records')
           end
 
           it 'overrides the response format with xml' do
             expect(RestClient::Request).to receive(:execute).with(hash_including(url: 'http://api.org/records.xml', headers: { 'Authentication-Token': '123' }))
 
-            subject.get('/records', {}, format: :xml)
+            requester.get('/records', {}, format: :xml)
           end
         end
 
-        context 'timeout' do
+        context 'when request timeouts' do
           it 'calculates the timeout' do
-            expect(subject).to receive(:timeout).with(hash_including(timeout: 60))
+            expect(requester).to receive(:timeout).with(hash_including(timeout: 60))
 
-            subject.get('/', {}, timeout: 60)
+            requester.get('/', {}, timeout: 60)
           end
         end
 
-        context 'restlclient unavailable' do
+        context 'when restlclient is unavailable' do
           it 'retries request 5 times' do
             allow(RestClient::Request).to receive(:execute).and_raise(RestClient::ServiceUnavailable)
             expect(RestClient::Request).to receive(:execute).exactly(5).times
 
             expect do
-              subject.get('/records')
+              requester.get('/records')
             end.to raise_error(RestClient::ServiceUnavailable)
           end
         end
@@ -81,7 +83,7 @@ module Supplejack
         it 'overrides the Supplejack.api_key' do
           expect(RestClient::Request).to receive(:execute).with(hash_including(url: 'http://api.org/records.json', headers: { 'Authentication-Token': '456' }))
 
-          subject.get('/records', {}, { authetication_token: '456' })
+          requester.get('/records', {}, { authetication_token: '456' })
         end
       end
     end
@@ -93,7 +95,7 @@ module Supplejack
         it 'executes a post request' do
           expect(RestClient::Request).to receive(:execute).with(hash_including(method: :post))
 
-          subject.post('/records/1/ucm', {})
+          requester.post('/records/1/ucm', {})
         end
 
         it 'passes the payload along' do
@@ -101,13 +103,13 @@ module Supplejack
 
           expect(RestClient::Request).to receive(:execute).with(hash_including(payload: payload.to_json))
 
-          subject.post('/records/1/ucm', {}, payload)
+          requester.post('/records/1/ucm', {}, payload)
         end
 
         it 'adds the extra parameters to the post request' do
-          expect(subject).to receive(:full_url).with('/records/1/ucm', nil, {})
+          expect(requester).to receive(:full_url).with('/records/1/ucm', nil, {})
 
-          subject.post('/records/1/ucm', {}, {})
+          requester.post('/records/1/ucm', {}, {})
         end
 
         it 'adds json headers and converts the payload into json' do
@@ -118,13 +120,13 @@ module Supplejack
             )
           )
 
-          subject.post('/records/1/ucm', {}, records: [{ record_id: 1, position: 1 }, { record_id: 2, position: 2 }])
+          requester.post('/records/1/ucm', {}, records: [{ record_id: 1, position: 1 }, { record_id: 2, position: 2 }])
         end
 
         it 'parses the JSON response' do
           allow(RestClient::Request).to receive(:execute).and_return({ user: { name: 'John' } }.to_json)
 
-          expect(subject.post('/users', {}, {})).to eq('user' => { 'name' => 'John' })
+          expect(requester.post('/users', {}, {})).to eq('user' => { 'name' => 'John' })
         end
       end
 
@@ -137,7 +139,7 @@ module Supplejack
             )
           )
 
-          subject.post('/records/1/ucm', {}, { records: [{ record_id: 1 }] }, { authetication_token: '456' })
+          requester.post('/records/1/ucm', {}, { records: [{ record_id: 1 }] }, { authetication_token: '456' })
         end
       end
     end
@@ -148,13 +150,13 @@ module Supplejack
       it 'executes a delete request' do
         expect(RestClient::Request).to receive(:execute).with(hash_including(method: :delete))
 
-        subject.delete('/records/1/ucm/1')
+        requester.delete('/records/1/ucm/1')
       end
 
       it 'adds the extra parameters to the delete request' do
-        expect(subject).to receive(:full_url).with('/records/1/ucm/1', nil, {})
+        expect(requester).to receive(:full_url).with('/records/1/ucm/1', nil, {})
 
-        subject.delete('/records/1/ucm/1', {}, {})
+        requester.delete('/records/1/ucm/1', {}, {})
       end
     end
 
@@ -164,31 +166,31 @@ module Supplejack
       it 'executes a put request' do
         expect(RestClient::Request).to receive(:execute).with(hash_including(method: :put))
 
-        subject.put('/records/1/ucm/1')
+        requester.put('/records/1/ucm/1')
       end
 
       it 'passes the payload along' do
         expect(RestClient::Request).to receive(:execute).with(hash_including(payload: { name: 1 }.to_json))
 
-        subject.put('/records/1/ucm/1', {}, name: 1)
+        requester.put('/records/1/ucm/1', {}, name: 1)
       end
 
       it 'adds the extra parameters to the put request' do
-        expect(subject).to receive(:full_url).with('/records/1/ucm/1', nil, {})
+        expect(requester).to receive(:full_url).with('/records/1/ucm/1', nil, {})
 
-        subject.put('/records/1/ucm/1', {}, {})
+        requester.put('/records/1/ucm/1', {}, {})
       end
 
       it 'adds json headers and converts the payload into json' do
         expect(RestClient::Request).to receive(:execute).with(hash_including(headers: { 'Authentication-Token': '123', content_type: :json, accept: :json }, payload: { records: [1, 2, 3] }.to_json))
 
-        subject.put('/records/1/ucm/1', {}, records: [1, 2, 3])
+        requester.put('/records/1/ucm/1', {}, records: [1, 2, 3])
       end
 
       it 'parses the JSON response' do
         allow(RestClient::Request).to receive(:execute).and_return({ user: { name: 'John' } }.to_json)
 
-        expect(subject.put('/users/1', {}, {})).to eq('user' => { 'name' => 'John' })
+        expect(requester.put('/users/1', {}, {})).to eq('user' => { 'name' => 'John' })
       end
     end
 
@@ -198,71 +200,71 @@ module Supplejack
       it 'executes a patch request' do
         expect(RestClient::Request).to receive(:execute).with(hash_including(method: :patch))
 
-        subject.patch('/records/1/ucm/1')
+        requester.patch('/records/1/ucm/1')
       end
 
       it 'passes the payload along' do
         expect(RestClient::Request).to receive(:execute).with(hash_including(payload: { name: 1 }.to_json))
 
-        subject.put('/records/1/ucm/1', {}, name: 1)
+        requester.put('/records/1/ucm/1', {}, name: 1)
       end
 
       it 'adds the extra parameters to the patch request' do
-        expect(subject).to receive(:full_url).with('/records/1/ucm/1', nil, {})
+        expect(requester).to receive(:full_url).with('/records/1/ucm/1', nil, {})
 
-        subject.patch('/records/1/ucm/1', {}, {})
+        requester.patch('/records/1/ucm/1', {}, {})
       end
 
       it 'adds json headers and converts the payload into json' do
         expect(RestClient::Request).to receive(:execute).with(hash_including(headers: { 'Authentication-Token': '123', content_type: :json, accept: :json }, payload: { records: [1, 2, 3] }.to_json))
 
-        subject.patch('/records/1/ucm/1', {}, records: [1, 2, 3])
+        requester.patch('/records/1/ucm/1', {}, records: [1, 2, 3])
       end
 
       it 'parses the JSON response' do
         allow(RestClient::Request).to receive(:execute).and_return({ user: { name: 'John' } }.to_json)
 
-        expect(subject.patch('/users/1', {}, {})).to eq('user' => { 'name' => 'John' })
+        expect(requester.patch('/users/1', {}, {})).to eq('user' => { 'name' => 'John' })
       end
     end
 
     describe '#timeout' do
       it 'defaults to the timeout in the configuration' do
-        expect(subject.send(:timeout)).to eq 20
+        expect(requester.send(:timeout)).to eq 20
       end
 
       it 'defaults to 30 when not set in the configuration' do
         allow(Supplejack).to receive(:timeout).and_return(nil)
 
-        expect(subject.send(:timeout)).to eq 15
+        expect(requester.send(:timeout)).to eq 15
       end
 
       it 'overrides the timeout' do
-        expect(subject.send(:timeout, timeout: 60)).to eq 60
+        expect(requester.send(:timeout, timeout: 60)).to eq 60
       end
     end
 
     describe '#full_url' do
       it 'returns the full url with default api_url, format and api_key' do
-        expect(subject.send(:full_url, '/records')).to eq('http://api.org/records.json')
+        expect(requester.send(:full_url, '/records')).to eq('http://api.org/records.json')
       end
 
       it 'overrides the format' do
-        expect(subject.send(:full_url, '/records', 'xml')).to eq('http://api.org/records.xml')
+        expect(requester.send(:full_url, '/records', 'xml')).to eq('http://api.org/records.xml')
       end
 
       it 'url encodes the parameters' do
-        expect(subject.send(:full_url, '/records', nil, api_key: '456', i: { category: 'Images' })).to eq('http://api.org/records.json?api_key=456&i%5Bcategory%5D=Images')
+        expect(requester.send(:full_url, '/records', nil, api_key: '456', i: { category: 'Images' })).to eq('http://api.org/records.json?api_key=456&i%5Bcategory%5D=Images')
       end
 
       it 'adds debug=true when enable_debugging is set to true' do
         allow(Supplejack).to receive(:enable_debugging).and_return(true)
 
-        expect(subject.send(:full_url, '/records', nil, {})).to eq 'http://api.org/records.json?debug=true'
+        expect(requester.send(:full_url, '/records', nil, {})).to eq 'http://api.org/records.json?debug=true'
       end
 
       it 'handles nil params' do
-        expect(subject.send(:full_url, '/records', nil, nil)).to eq 'http://api.org/records.json'
+        expect(requester.send(:full_url, '/records', nil, nil)).to eq 'http://api.org/records.json'
       end
     end
   end

--- a/spec/supplejack/search_spec.rb
+++ b/spec/supplejack/search_spec.rb
@@ -10,8 +10,6 @@ class TestItem
   def initialize(attributes = {}) end
 end
 
-# rubocop:disable Metrics/BlockLength
-# rubocop:disable Metrics/ModuleLength
 module Supplejack
   describe Search do
     describe '#params' do
@@ -100,116 +98,115 @@ module Supplejack
     end
 
     describe '#filters' do
-      before(:each) do
-        @filters = { location: 'Wellington', country: 'New Zealand' }
-      end
+      let(:filters) { { location: 'Wellington', country: 'New Zealand' } }
 
       it 'returns filters in a array format by default' do
-        expect(Search.new(i: @filters).filters).to include([:location, 'Wellington'], [:country, 'New Zealand'])
+        expect(Search.new(i: filters).filters).to include([:location, 'Wellington'], [:country, 'New Zealand'])
       end
 
       it 'returns a hash of the current search filters' do
-        expect(Search.new(i: @filters).filters(format: :hash)).to include(@filters)
+        expect(Search.new(i: filters).filters(format: :hash)).to include(filters)
       end
 
       it 'expands filters that contain arrays' do
-        @filters = { location: %w[Wellington Auckland] }
-        expect(Search.new(i: @filters).filters).to include([:location, 'Wellington'], [:location, 'Auckland'])
+        filters = { location: %w[Wellington Auckland] }
+        expect(Search.new(i: filters).filters).to include([:location, 'Wellington'], [:location, 'Auckland'])
       end
 
       it 'removes the location filter' do
-        @filters = { location: %w[Wellington Auckland] }
-        expect(Search.new(i: @filters).filters(except: [:location])).not_to include([:location, 'Wellington'], [:location, 'Auckland'])
+        filters = { location: %w[Wellington Auckland] }
+        expect(Search.new(i: filters).filters(except: [:location])).not_to include([:location, 'Wellington'], [:location, 'Auckland'])
       end
     end
 
     describe '#facets' do
-      before(:each) do
-        @search = Search.new
+      let(:search) { Search.new }
+      let(:facets_hash) { { 'location' => { 'Wellington' => 100 }, 'mayor' => { 'Brake, Brian' => 20 } } }
+
+      before do
         Supplejack.facets = [:location]
-        @facets_hash = { 'location' => { 'Wellington' => 100 }, 'mayor' => { 'Brake, Brian' => 20 } }
-        @search.instance_variable_set(:@response, 'search' => { 'facets' => @facets_hash })
+        search.instance_variable_set(:@response, 'search' => { 'facets' => facets_hash })
       end
 
       it 'executes the request only once' do
-        expect(@search).to receive(:execute_request).once
+        expect(search).to receive(:execute_request).once
 
-        @search.facets
-        @search.facets
+        search.facets
+        search.facets
       end
 
       it 'handles a failed request from the API' do
-        @search.instance_variable_set(:@response, 'search' => {})
-        expect(@search.facets.empty?).to be true
+        search.instance_variable_set(:@response, 'search' => {})
+        expect(search.facets.empty?).to be true
       end
 
       it 'initializes a facet object for each facet' do
         expect(Supplejack::Facet).to receive(:new).with('location', 'Wellington' => 100)
         expect(Supplejack::Facet).to receive(:new).with('mayor', 'Brake, Brian' => 20)
 
-        @search.facets
+        search.facets
       end
 
       it 'orders the facets based on the order set in the initializer' do
         allow(Supplejack).to receive(:facets) { %i[mayor location] }
 
-        expect(@search.facets.first.name).to eq 'mayor'
-        expect(@search.facets.last.name).to eq 'location'
+        expect(search.facets.first.name).to eq 'mayor'
+        expect(search.facets.last.name).to eq 'location'
       end
 
       it 'orders the facets the other way around' do
         allow(Supplejack).to receive(:facets) { %i[location mayor] }
 
-        expect(@search.facets.first.name).to eq 'location'
-        expect(@search.facets.last.name).to eq 'mayor'
+        expect(search.facets.first.name).to eq 'location'
+        expect(search.facets.last.name).to eq 'mayor'
       end
 
       it 'returns the facet values' do
-        expect(@search.facets.first.values).to eq('Wellington' => 100)
+        expect(search.facets.first.values).to eq('Wellington' => 100)
       end
     end
 
     describe '#facet' do
-      before { @search = Search.new }
+      let(:search) { Search.new }
 
       it 'returns the specified facet' do
         facet = Supplejack::Facet.new('collection', [])
-        allow(@search).to receive(:facets) { [facet] }
+        allow(search).to receive(:facets) { [facet] }
 
-        expect(@search.facet('collection')).to eq facet
+        expect(search.facet('collection')).to eq facet
       end
 
       it 'returns nil when facet is not found' do
-        allow(@search).to receive(:facets) { [] }
+        allow(search).to receive(:facets) { [] }
 
-        expect(@search.facet('collection')).to be nil
+        expect(search.facet('collection')).to be nil
       end
 
       it 'returns nil if value is nil' do
         facet = Supplejack::Facet.new('collection', [])
-        allow(@search).to receive(:facets) { [facet] }
+        allow(search).to receive(:facets) { [facet] }
 
-        expect(@search.facet(nil)).to be nil
+        expect(search.facet(nil)).to be nil
       end
     end
 
     describe '#facet_pivots' do
-      before { @search = Search.new }
+      let(:search) { Search.new }
 
       it 'returns empty array when there are no facet pivots' do
-        @search.instance_variable_set(:@response, 'search' => {})
+        search.instance_variable_set(:@response, 'search' => {})
 
-        expect(@search.facet_pivots).to eq []
+        expect(search.facet_pivots).to eq []
       end
 
       it 'returns empty array when there are empty facet pivots' do
-        @search.instance_variable_set(:@response, 'search' => { 'facet_pivots' => {} })
+        search.instance_variable_set(:@response, 'search' => { 'facet_pivots' => {} })
 
-        expect(@search.facet_pivots).to eq []
+        expect(search.facet_pivots).to eq []
       end
 
       it 'returns facet_pivots correct when there are facet pivots' do
-        @search.instance_variable_set(:@response, 'search' => { facet_pivots:
+        search.instance_variable_set(:@response, 'search' => { facet_pivots:
           {
             'display_collection_s' =>
               [
@@ -221,306 +218,302 @@ module Supplejack
               ]
           } })
 
-        expect(@search.facet_pivots).to_not eq []
+        expect(search.facet_pivots).to_not eq []
       end
     end
 
     describe '#total' do
-      before(:each) do
-        @search = Search.new
-        @search.instance_variable_set(:@response, 'search' => { 'result_count' => 100 })
-      end
+      let(:search) { Search.new }
+
+      before { search.instance_variable_set(:@response, 'search' => { 'result_count' => 100 }) }
 
       it 'executes the request only once' do
-        expect(@search).to receive(:execute_request).once
-        @search.total
-        @search.total
+        expect(search).to receive(:execute_request).once
+        search.total
+        search.total
       end
 
       it 'returns the total from the response' do
-        expect(@search.total).to eq 100
+        expect(search.total).to eq 100
       end
 
       it 'returns 0 when the request to the API failed' do
-        @search.instance_variable_set(:@response, 'search' => {})
+        search.instance_variable_set(:@response, 'search' => {})
 
-        expect(@search.total).to eq 0
+        expect(search.total).to eq 0
       end
     end
 
     describe '#results' do
-      before(:each) do
-        allow(Supplejack).to receive(:record_klass).and_return('TestRecord')
+      let(:search)  { Search.new }
+      let(:record1) { { 'id' => 1, 'title' => 'Wellington' } }
+      let(:record2) { { 'id' => 2, 'title' => 'Auckland' } }
 
-        @search = Search.new
-        @record1 = { 'id' => 1, 'title' => 'Wellington' }
-        @record2 = { 'id' => 2, 'title' => 'Auckland' }
-        @search.instance_variable_set(:@response, 'search' => { 'results' => [@record1, @record2] })
+      before do
+        allow(Supplejack).to receive(:record_klass).and_return('TestRecord')
+        search.instance_variable_set(:@response, 'search' => { 'results' => [record1, record2] })
       end
 
       it 'executes the request only once' do
-        allow(@search).to receive(:total) { 10 }
+        allow(search).to receive(:total) { 10 }
 
-        expect(@search).to receive(:execute_request).once
+        expect(search).to receive(:execute_request).once
 
-        @search.results
-        @search.results
+        search.results
+        search.results
       end
 
       it 'initializes record objects with the default class' do
-        expect(TestRecord).to receive(:new).with(@record1)
-        expect(TestRecord).to receive(:new).with(@record2)
+        expect(TestRecord).to receive(:new).with(record1)
+        expect(TestRecord).to receive(:new).with(record2)
 
-        @search.results
+        search.results
       end
 
       it 'initializes record objects with the class provided in the params' do
-        @search = Search.new(record_klass: 'test_item')
-        @search.instance_variable_set(:@response, 'search' => { 'results' => [@record1, @record2] })
+        search = Search.new(record_klass: 'test_item')
+        search.instance_variable_set(:@response, 'search' => { 'results' => [record1, record2] })
 
-        expect(TestItem).to receive(:new).with(@record1)
-        expect(TestItem).to receive(:new).with(@record2)
+        expect(TestItem).to receive(:new).with(record1)
+        expect(TestItem).to receive(:new).with(record2)
 
-        @search.results
+        search.results
       end
 
       it 'returns a array of objects of the provided class' do
-        expect(@search.results.first.class).to eq TestRecord
+        expect(search.results.first.class).to eq TestRecord
       end
 
       it 'returns an array wraped in paginated collection object' do
-        expect(@search.results.current_page).to eq 1
+        expect(search.results.current_page).to eq 1
       end
 
       it 'returns empty paginated collection when API request failed' do
-        @search.instance_variable_set(:@response, 'search' => {})
+        search.instance_variable_set(:@response, 'search' => {})
 
-        expect(@search.results.size).to eq 0
+        expect(search.results.size).to eq 0
       end
     end
 
     describe '#counts' do
-      before(:each) do
-        @search = Search.new
+      let(:search) { Search.new }
 
-        allow(@search).to receive(:fetch_counts) { { 'images' => 100 } }
-      end
+      before { allow(search).to receive(:fetch_counts) { { 'images' => 100 } } }
 
       context 'caching disabled' do
-        before(:each) do
-          allow(Supplejack).to receive(:enable_caching) { false }
-        end
+        before { allow(Supplejack).to receive(:enable_caching) { false } }
 
         it 'fetches the counts' do
           query_params = { 'images' => { category: 'Images' } }
 
-          expect(@search).to receive(:fetch_counts).with(query_params)
+          expect(search).to receive(:fetch_counts).with(query_params)
 
-          @search.counts(query_params)
+          search.counts(query_params)
         end
       end
     end
 
     describe '#fetch_counts' do
       context 'without filters' do
-        before { @search = Search.new }
+        let(:search) { Search.new }
 
         it 'returns a hash with row names and its values' do
-          allow(@search).to receive(:get).and_return('search' => { 'facets' => { 'counts' => { 'images' => 151_818 } } })
+          allow(search).to receive(:get).and_return('search' => { 'facets' => { 'counts' => { 'images' => 151_818 } } })
 
-          expect(@search.fetch_counts({})).to eq('images' => 151_818)
+          expect(search.fetch_counts({})).to eq('images' => 151_818)
         end
 
         it 'returns every count even when there are no results matching' do
-          allow(@search).to receive(:get).and_return('search' => { 'facets' => { 'counts' => { 'images' => 151_818 } } })
+          allow(search).to receive(:get).and_return('search' => { 'facets' => { 'counts' => { 'images' => 151_818 } } })
 
-          expect(@search.fetch_counts(images: {}, headings: {})).to eq('images' => 151_818, 'headings' => 0)
+          expect(search.fetch_counts(images: {}, headings: {})).to eq('images' => 151_818, 'headings' => 0)
         end
 
         it 'returns 0 for every facet when the API response fails' do
-          allow(@search).to receive(:get).and_raise(StandardError)
+          allow(search).to receive(:get).and_raise(StandardError)
 
-          expect(@search.fetch_counts(images: {})).to eq('images' => 0)
+          expect(search.fetch_counts(images: {})).to eq('images' => 0)
         end
       end
     end
 
     describe '#counts_params' do
       context 'without filters' do
-        before { @search = Search.new }
+        let(:search) { Search.new }
 
         it 'requests record_type == all' do
           query_parameters = { headings: { record_type: '1' } }
 
-          expect(@search.counts_params(query_parameters)).to include(facet_query: query_parameters, record_type: 'all')
+          expect(search.counts_params(query_parameters)).to include(facet_query: query_parameters, record_type: 'all')
         end
 
         it 'adds the restrictions set in the without variable' do
           query_parameters = { headings: { record_type: '1' } }
-          @search.without = { location: 'Wellington' }
+          search.without = { location: 'Wellington' }
 
-          expect(@search.counts_params(query_parameters)).to include(without: { location: 'Wellington' })
+          expect(search.counts_params(query_parameters)).to include(without: { location: 'Wellington' })
         end
 
         it 'restricts the result set to only ones that match the and filters' do
           query_parameters = { headings: { record_type: '1' } }
-          @search.and = { location: 'Wellington' }
+          search.and = { location: 'Wellington' }
 
-          expect(@search.counts_params(query_parameters)).to include(and: { location: 'Wellington' })
+          expect(search.counts_params(query_parameters)).to include(and: { location: 'Wellington' })
         end
 
         it 'restricts the result set to results that match any of the or filters' do
           query_parameters = { headings: { record_type: '1' } }
-          @search.or = { location: %w[Wellington Auckland] }
+          search.or = { location: %w[Wellington Auckland] }
 
-          expect(@search.counts_params(query_parameters)).to include(or: { location: %w[Wellington Auckland] })
+          expect(search.counts_params(query_parameters)).to include(or: { location: %w[Wellington Auckland] })
         end
 
         it 'executes a request with facet_queries' do
           query_parameters = { images: { creator: 'all', record_type: '0' }, headings: { record_type: '1' } }
 
-          expect(@search.counts_params(query_parameters)).to include(facet_query: query_parameters)
+          expect(search.counts_params(query_parameters)).to include(facet_query: query_parameters)
         end
 
         it 'passes the text when present' do
-          @search = Search.new(text: 'dogs')
+          search = Search.new(text: 'dogs')
 
-          expect(@search.counts_params({})).to include(text: 'dogs')
+          expect(search.counts_params({})).to include(text: 'dogs')
         end
 
         it 'merges the :i and :il filters with record_type 0' do
           query_parameters = { images: { 'creator' => 'all', 'record_type' => '0' }, headings: { 'record_type' => '1', :dc_type => 'Group' } }
-          @search = Search.new(i: { category: 'Images' }, il: { year: '1998' })
+          search = Search.new(i: { category: 'Images' }, il: { year: '1998' })
 
           images_query = { creator: 'all', record_type: '0', category: 'Images', year: '1998' }
           headings_query = { record_type: '1', dc_type: 'Group' }
 
-          expect(@search.counts_params(query_parameters)).to include(facet_query: { images: images_query, headings: headings_query })
+          expect(search.counts_params(query_parameters)).to include(facet_query: { images: images_query, headings: headings_query })
         end
 
         it 'merges *_text fields' do
           query_parameters = { images: { 'creator' => 'all', 'record_type' => '0' } }
-          @search = Search.new(i: { subject_text: 'dog' })
+          search = Search.new(i: { subject_text: 'dog' })
 
           images_query = { creator: 'all', record_type: '0' }
 
-          expect(@search.counts_params(query_parameters)).to include(text: 'dog', query_fields: [:subject], facet_query: { images: images_query })
+          expect(search.counts_params(query_parameters)).to include(text: 'dog', query_fields: [:subject], facet_query: { images: images_query })
         end
       end
 
       context 'with active filters' do
-        before { @search = Search.new(i: { location: 'Wellington' }) }
+        let(:search) { Search.new(i: { location: 'Wellington' }) }
 
         it 'merges the existing filters into every facet query' do
           query_parameters = { images: { 'creator' => 'all', 'record_type' => 0 } }
           expected_filters = { images: { creator: 'all', location: 'Wellington', record_type: 0 } }
 
-          expect(@search.counts_params(query_parameters)).to include(facet_query: expected_filters)
+          expect(search.counts_params(query_parameters)).to include(facet_query: expected_filters)
         end
 
         it 'merges existing filters without overriding' do
           query_parameters = { images: { 'location' => 'Matapihi', 'record_type' => 0 } }
           expected_filters = { images: { location: %w[Wellington Matapihi], record_type: 0 } }
 
-          expect(@search.counts_params(query_parameters)).to include(facet_query: expected_filters)
+          expect(search.counts_params(query_parameters)).to include(facet_query: expected_filters)
         end
 
         it 'overrides the record_type' do
-          @search = Search.new(record_type: '1')
+          search = Search.new(record_type: '1')
           query_parameters = { images: { 'record_type' => '0' } }
           expected_filters = { images: { record_type: '0' } }
 
-          expect(@search.counts_params(query_parameters)).to include(facet_query: expected_filters)
+          expect(search.counts_params(query_parameters)).to include(facet_query: expected_filters)
         end
 
         it 'merges existing negative filters' do
-          @search = Search.new(i: { '-category' => 'Groups' })
+          search = Search.new(i: { '-category' => 'Groups' })
           query_parameters = { photos: { 'has_large_thumbnail_url' => 'Y' } }
           expected_filters = { photos: { has_large_thumbnail_url: 'Y', '-category'.to_sym => 'Groups' } }
 
-          expect(@search.counts_params(query_parameters)).to include(facet_query: expected_filters)
+          expect(search.counts_params(query_parameters)).to include(facet_query: expected_filters)
         end
 
         it 'adds per_page params if present' do
-          @search = Search.new(per_page: 0)
+          search = Search.new(per_page: 0)
 
-          expect(@search.counts_params({})).to include(per_page: 0)
+          expect(search.counts_params({})).to include(per_page: 0)
         end
       end
     end
 
     describe '#request_path' do
-      before { @search = Search.new }
+      let(:search) { Search.new }
 
       it 'returns /records by default' do
-        expect(@search.request_path).to eq '/records'
+        expect(search.request_path).to eq '/records'
       end
     end
 
     describe '#execute_request' do
-      before { @search = Search.new }
+      let(:search) { Search.new }
 
       it 'only executes the request once' do
-        expect(@search).to receive(:get).once.and_return('{}')
+        expect(search).to receive(:get).once.and_return('{}')
 
-        @search.execute_request
-        @search.execute_request
+        search.execute_request
+        search.execute_request
       end
 
       it 'removes the results that match the without filters' do
-        @search.without = { location: 'Wellington' }
+        search.without = { location: 'Wellington' }
 
-        expect(@search).to receive(:get).with('/records', hash_including(without: { location: 'Wellington' }))
+        expect(search).to receive(:get).with('/records', hash_including(without: { location: 'Wellington' }))
 
-        @search.execute_request
+        search.execute_request
       end
 
       it 'restricts the result set to only ones that match the and filters' do
-        @search.and = { location: 'Wellington' }
+        search.and = { location: 'Wellington' }
 
-        expect(@search).to receive(:get).with('/records', hash_including(and: { location: 'Wellington' }))
+        expect(search).to receive(:get).with('/records', hash_including(and: { location: 'Wellington' }))
 
-        @search.execute_request
+        search.execute_request
       end
 
       it 'restricts the result set to only ones that match any of the or filters' do
-        @search.or = { location: ['Wellington'] }
+        search.or = { location: ['Wellington'] }
 
-        expect(@search).to receive(:get).with('/records', hash_including(or: { location: ['Wellington'] }))
+        expect(search).to receive(:get).with('/records', hash_including(or: { location: ['Wellington'] }))
 
-        @search.execute_request
+        search.execute_request
       end
 
       it 'returns a empty search hash when a error is raised' do
-        allow(@search).to receive(:get).and_raise(StandardError)
+        allow(search).to receive(:get).and_raise(StandardError)
 
-        expect(@search.execute_request).to eq('search' => {})
+        expect(search.execute_request).to eq('search' => {})
       end
 
       context 'error handling' do
         it 'raises a timeout error' do
-          allow(@search).to receive(:get).and_raise(RestClient::Exceptions::ReadTimeout)
+          allow(search).to receive(:get).and_raise(RestClient::Exceptions::ReadTimeout)
 
-          expect { @search.execute_request }.to raise_error(Supplejack::RequestTimeout)
+          expect { search.execute_request }.to raise_error(Supplejack::RequestTimeout)
         end
 
         it 'raises a unavailable error' do
-          allow(@search).to receive(:get).and_raise(RestClient::ServiceUnavailable)
+          allow(search).to receive(:get).and_raise(RestClient::ServiceUnavailable)
 
-          expect { @search.execute_request }.to raise_error(Supplejack::ApiNotAvailable)
+          expect { search.execute_request }.to raise_error(Supplejack::ApiNotAvailable)
         end
 
         it 'raises no error but returns an empty search' do
-          allow(@search).to receive(:get).and_raise(StandardError)
+          allow(search).to receive(:get).and_raise(StandardError)
 
-          expect(@search.execute_request).to eq('search' => {})
+          expect(search.execute_request).to eq('search' => {})
         end
       end
 
       context 'caching enabled' do
-        before :each do
-          @cache = double(:cache).as_null_object
-          allow(Rails).to receive(:cache) { @cache }
+        let(:cache) { double(:cache).as_null_object }
+
+        before do
+          allow(Rails).to receive(:cache) { cache }
           allow(Supplejack).to receive(:enable_caching) { true }
         end
 
@@ -559,120 +552,120 @@ module Supplejack
     end
 
     describe '#has_attribute_name?' do
-      before do
-        @search = Search.new
-        @search.location = %w[Wellington Auckland]
-      end
+      let(:search) { Search.new }
+
+      before { search.location = %w[Wellington Auckland] }
 
       it 'returns true if value is in filter' do
-        expect(@search.has_location?('Wellington')).to be true
+        expect(search.has_location?('Wellington')).to be true
       end
 
       it 'returns false is value is not in filter' do
-        expect(@search.has_location?('Videos')).to be false
+        expect(search.has_location?('Videos')).to be false
       end
 
       context 'search filter is single valued' do
-        before(:each) do
-          @search = Search.new
-          @search.location = 'Wellington'
-        end
+        let(:search) { Search.new }
+
+        before { search.location = 'Wellington' }
 
         it 'returns true if value matches filter' do
-          expect(@search.has_location?('Wellington')).to be true
+          expect(search.has_location?('Wellington')).to be true
         end
 
         it 'returns false if value does not match the filter' do
-          expect(@search.has_location?('Cats')).to be false
+          expect(search.has_location?('Cats')).to be false
         end
 
         it 'returns false when location has nil value' do
-          @search.location = nil
+          search.location = nil
 
-          expect(@search.has_category?('Cats')).to be nil
+          expect(search.has_category?('Cats')).to be nil
         end
 
         it 'shouldn\'t search for a non existent search attribute' do
           allow(Supplejack).to receive(:search_attributes) { [] }
 
-          expect(@search).not_to receive(:filter_and_value?)
-          @search.has_category?('Cats')
+          expect(search).not_to receive(:filter_and_value?)
+          search.has_category?('Cats')
         end
       end
     end
 
     describe '#categories' do
-      before(:each) do
-        @search = Search.new(i: { category: 'Books', year: 2001 }, text: 'Dogs')
-        allow(@search).to receive(:get) { { 'search' => { 'facets' => { 'category' => { 'Books' => 123 } }, 'result_count' => 123 } } }
+      let(:search) { Search.new(i: { category: 'Books', year: 2001 }, text: 'Dogs') }
+
+      before do
+        allow(search).to receive(:get) { { 'search' => { 'facets' => { 'category' => { 'Books' => 123 } }, 'result_count' => 123 } } }
       end
 
       it 'should call the fetch_values method' do
-        expect(@search).to receive(:facet_values).with('category', {})
+        expect(search).to receive(:facet_values).with('category', {})
 
-        @search.categories
+        search.categories
       end
 
       it 'removes category filter from the search request' do
-        expect(@search).to receive(:get).with('/records', hash_including(and: { year: 2001 })).and_return('search' => { 'facets' => { 'category' => { 'Books' => 123 } } })
+        expect(search).to receive(:get).with('/records', hash_including(and: { year: 2001 })).and_return('search' => { 'facets' => { 'category' => { 'Books' => 123 } } })
 
-        @search.categories
+        search.categories
       end
 
       it 'returns the category facet hash ' do
-        expect(@search.categories).to include('Books' => 123)
+        expect(search.categories).to include('Books' => 123)
       end
 
       it 'asks the API for 0 results' do
-        expect(@search).to receive(:get).with('/records', hash_including(per_page: 0))
+        expect(search).to receive(:get).with('/records', hash_including(per_page: 0))
 
-        @search.categories
+        search.categories
       end
 
       it 'should return add the All count to the hash' do
-        expect(@search.categories['All']).to eq 123
+        expect(search.categories['All']).to eq 123
       end
 
       it 'orders the category values by :count' do
-        expect(@search).to receive(:facet_values).with('category', sort: :count)
+        expect(search).to receive(:facet_values).with('category', sort: :count)
 
-        @search.categories(sort: :count)
+        search.categories(sort: :count)
       end
     end
 
     describe '#fetch_facet_values' do
-      before(:each) do
-        @search = Search.new(i: { category: 'Books', year: 2001 }, text: 'Dogs')
-        allow(@search).to receive(:get) { { 'search' => { 'facets' => { 'category' => { 'Books' => 123, 'Images' => 100 } }, 'result_count' => 123 } } }
+      let(:search) { Search.new(i: { category: 'Books', year: 2001 }, text: 'Dogs') }
+
+      before do
+        allow(search).to receive(:get) { { 'search' => { 'facets' => { 'category' => { 'Books' => 123, 'Images' => 100 } }, 'result_count' => 123 } } }
       end
 
       it 'returns the category facet hash' do
-        expect(@search.fetch_facet_values('category')).to include('Books' => 123)
+        expect(search.fetch_facet_values('category')).to include('Books' => 123)
       end
 
       it 'returns empty values when the request to the API failed' do
-        allow(@search).to receive(:get).and_raise(StandardError)
+        allow(search).to receive(:get).and_raise(StandardError)
 
-        expect(@search.fetch_facet_values('category')).to eq('All' => 0)
+        expect(search.fetch_facet_values('category')).to eq('All' => 0)
       end
 
       it 'should add the All count to the hash with the sum of all facets' do
-        expect(@search.fetch_facet_values('category')['All']).to eq 223
+        expect(search.fetch_facet_values('category')['All']).to eq 223
       end
 
       it 'doesnt return the All count ' do
-        expect(@search.fetch_facet_values('category', all: false)).not_to have_key('All')
+        expect(search.fetch_facet_values('category', all: false)).not_to have_key('All')
       end
 
       it 'memoizes the facet_values' do
-        expect(@search).to receive(:get).once
+        expect(search).to receive(:get).once
 
-        @search.fetch_facet_values('category')
-        @search.fetch_facet_values('category')
+        search.fetch_facet_values('category')
+        search.fetch_facet_values('category')
       end
 
       context 'sorting' do
-        before(:each) do
+        before do
           @facet = Supplejack::Facet.new('category', 'All' => 223, 'Books' => 123, 'Images' => 100)
           allow(Supplejack::Facet).to receive(:new) { @facet }
         end
@@ -680,99 +673,98 @@ module Supplejack
         it 'initializes a Supplejack::Facet' do
           expect(Supplejack::Facet).to receive(:new).with('category', 'All' => 223, 'Books' => 123, 'Images' => 100)
 
-          @search.fetch_facet_values('category')
+          search.fetch_facet_values('category')
         end
 
         it 'tells the facet how to sort the values' do
           expect(@facet).to receive(:values).with(:index)
 
-          @search.fetch_facet_values('category', sort: :index)
+          search.fetch_facet_values('category', sort: :index)
         end
 
         it 'doesn\'t sort by default' do
           expect(@facet).to receive(:values).with(nil)
 
-          @search.fetch_facet_values('category')
+          search.fetch_facet_values('category')
         end
       end
     end
 
     describe 'facet_values_params' do
-      before(:each) do
-        @search = Search.new(i: { type: 'Person', year: 2001 }, text: 'Dogs')
-      end
+      let(:search) { Search.new(i: { type: 'Person', year: 2001 }, text: 'Dogs') }
 
       it 'removes type filter from the search request' do
-        expect(@search.facet_values_params('type')).to include(and: { year: 2001 })
+        expect(search.facet_values_params('type')).to include(and: { year: 2001 })
       end
 
       it 'requests 0 results per_page' do
-        expect(@search.facet_values_params('type')).to include(per_page: 0)
+        expect(search.facet_values_params('type')).to include(per_page: 0)
       end
 
       it 'adds without filters' do
-        @search = Search.new(i: { :type => 'Person', :year => 2001, '-group' => 'Group' }, text: 'Dogs')
+        search = Search.new(i: { :type => 'Person', :year => 2001, '-group' => 'Group' }, text: 'Dogs')
 
-        expect(@search.facet_values_params('type')).to include(without: { group: 'Group' })
+        expect(search.facet_values_params('type')).to include(without: { group: 'Group' })
       end
 
       it 'only adds the and_filters to :and' do
-        @search = Search.new(i: { :type => 'Person', :year => 2001, '-group' => 'Group' }, text: 'Dogs')
+        search = Search.new(i: { :type => 'Person', :year => 2001, '-group' => 'Group' }, text: 'Dogs')
 
-        expect(@search.facet_values_params('type')).to include(and: { year: 2001 })
+        expect(search.facet_values_params('type')).to include(and: { year: 2001 })
       end
 
       it 'gets the facet_values for a record_type 1' do
-        @search = Search.new(i: { type: 'Person' }, h: { group: 'Group' }, text: 'Dogs', record_type: 1)
+        search = Search.new(i: { type: 'Person' }, h: { group: 'Group' }, text: 'Dogs', record_type: 1)
 
-        expect(@search.facet_values_params('group')).to include(and: {})
+        expect(search.facet_values_params('group')).to include(and: {})
       end
 
       it 'restricts results to filters specified in without accessor' do
-        @search = Search.new
-        @search.without = { website: 'Flickr' }
+        search = Search.new
+        search.without = { website: 'Flickr' }
 
-        expect(@search.facet_values_params('type')).to include(without: { website: 'Flickr' })
+        expect(search.facet_values_params('type')).to include(without: { website: 'Flickr' })
       end
 
       it 'merges in the filters specified in without' do
-        @search = Search.new(i: { '-type' => 'Person' })
-        @search.without = { website: 'Flickr' }
+        search = Search.new(i: { '-type' => 'Person' })
+        search.without = { website: 'Flickr' }
 
-        expect(@search.facet_values_params('type')).to include(without: { website: 'Flickr', type: 'Person' })
+        expect(search.facet_values_params('type')).to include(without: { website: 'Flickr', type: 'Person' })
       end
 
       it 'adds the restrictions set in the and variable' do
-        @search = Search.new
-        @search.and = { content_partner: 'NLNZ' }
+        search = Search.new
+        search.and = { content_partner: 'NLNZ' }
 
-        expect(@search.facet_values_params('type')).to include(and: { content_partner: 'NLNZ' })
+        expect(search.facet_values_params('type')).to include(and: { content_partner: 'NLNZ' })
       end
 
       it 'adds the restrictions set in the or variable' do
-        @search = Search.new
-        @search.or = { content_partner: 'NLNZ' }
+        search = Search.new
+        search.or = { content_partner: 'NLNZ' }
 
-        expect(@search.facet_values_params('type')).to include(or: { content_partner: 'NLNZ' })
+        expect(search.facet_values_params('type')).to include(or: { content_partner: 'NLNZ' })
       end
 
       it 'memoizes the params' do
-        @search = Search.new
-        expect(@search).to receive(:url_format).once.and_return(double(:url_format, and_filters: {}))
+        search = Search.new
+        expect(search).to receive(:url_format).once.and_return(double(:url_format, and_filters: {}))
 
-        @search.facet_values_params('type')
-        @search.facet_values_params('type')
+        search.facet_values_params('type')
+        search.facet_values_params('type')
       end
 
       it 'adds a parameter for facets_per_page if the option is present' do
-        expect(@search.facet_values_params('type', facets_per_page: 15)).to include(facets_per_page: 15)
+        expect(search.facet_values_params('type', facets_per_page: 15)).to include(facets_per_page: 15)
       end
     end
 
     describe '#facet_values' do
+      let(:search) { Search.new }
+
       before do
-        @search = Search.new
-        allow(@search).to receive(:fetch_facet_values) { { 'Books' => 100 } }
+        allow(search).to receive(:fetch_facet_values) { { 'Books' => 100 } }
       end
 
       context 'caching disabled' do
@@ -781,35 +773,33 @@ module Supplejack
         end
 
         it 'fetches the facet values' do
-          expect(@search).to receive(:fetch_facet_values).with('category', anything)
+          expect(search).to receive(:fetch_facet_values).with('category', anything)
 
-          @search.facet_values('category', anything)
+          search.facet_values('category', anything)
         end
       end
     end
 
     describe '#merge_extra_filters' do
-      before { @search = Search.new }
+      let(:search) { Search.new }
 
       it 'merges the and filters' do
-        @search.and = { type: 'Person' }
+        search.and = { type: 'Person' }
 
-        expect(@search.merge_extra_filters(and: { location: 'Wellington' })).to eq(and: { location: 'Wellington', type: 'Person' })
+        expect(search.merge_extra_filters(and: { location: 'Wellington' })).to eq(and: { location: 'Wellington', type: 'Person' })
       end
 
       it 'merges the or filters' do
-        @search.or = { type: 'Person' }
+        search.or = { type: 'Person' }
 
-        expect(@search.merge_extra_filters(and: { location: 'Wellington' })).to eq(and: { location: 'Wellington' }, or: { type: 'Person' })
+        expect(search.merge_extra_filters(and: { location: 'Wellington' })).to eq(and: { location: 'Wellington' }, or: { type: 'Person' })
       end
 
       it 'merges the without filters' do
-        @search.without = { type: 'Person' }
+        search.without = { type: 'Person' }
 
-        expect(@search.merge_extra_filters(and: { location: 'Wellington' })).to eq(and: { location: 'Wellington' }, without: { type: 'Person' })
+        expect(search.merge_extra_filters(and: { location: 'Wellington' })).to eq(and: { location: 'Wellington' }, without: { type: 'Person' })
       end
     end
   end
 end
-# rubocop:enable Metrics/BlockLength
-# rubocop:enable Metrics/ModuleLength

--- a/spec/supplejack/search_spec.rb
+++ b/spec/supplejack/search_spec.rb
@@ -14,27 +14,27 @@ module Supplejack
   describe Search do
     describe '#params' do
       it 'defaults to facets set in initializer' do
-        allow(Supplejack).to receive(:facets) { %w[location description] }
+        allow(Supplejack).to receive(:facets).and_return(%w[location description])
 
-        expect(Search.new.api_params[:facets]).to eq('location,description')
+        expect(described_class.new.api_params[:facets]).to eq('location,description')
       end
 
       it 'sets the facets through the params' do
-        expect(Search.new(facets: 'name,description').api_params[:facets]).to eq('name,description')
+        expect(described_class.new(facets: 'name,description').api_params[:facets]).to eq('name,description')
       end
 
       it 'defaults to facets_per_page set in initializer' do
-        allow(Supplejack).to receive(:facets_per_page) { 33 }
+        allow(Supplejack).to receive(:facets_per_page).and_return(33)
 
-        expect(Search.new.api_params[:facets_per_page]).to eq 33
+        expect(described_class.new.api_params[:facets_per_page]).to eq 33
       end
 
       it 'sets the facets_per_page through the params' do
-        expect(Search.new(facets_per_page: 13).api_params[:facets_per_page]).to eq 13
+        expect(described_class.new(facets_per_page: 13).api_params[:facets_per_page]).to eq 13
       end
 
       it 'deletes rails specific params' do
-        params = Search.new(controller: 'records', action: 'index').api_params
+        params = described_class.new(controller: 'records', action: 'index').api_params
 
         expect(params).not_to have_key(:controller)
         expect(params).not_to have_key(:action)
@@ -43,57 +43,57 @@ module Supplejack
 
     describe '#text' do
       it 'returns the search text' do
-        expect(Search.new(text: 'dog').text).to eq('dog')
+        expect(described_class.new(text: 'dog').text).to eq('dog')
       end
     end
 
     describe '#page' do
       it 'defaults to 1' do
-        expect(Search.new.page).to eq 1
+        expect(described_class.new.page).to eq 1
       end
 
       it 'converts the page to a number' do
-        expect(Search.new(page: '2').page).to eq 2
+        expect(described_class.new(page: '2').page).to eq 2
       end
     end
 
     describe '#per_page' do
       it 'defaults to the per_page in the initializer' do
-        allow(Supplejack).to receive(:per_page) { 16 }
+        allow(Supplejack).to receive(:per_page).and_return(16)
 
-        expect(Search.new.per_page).to eq 16
+        expect(described_class.new.per_page).to eq 16
       end
 
       it 'sers the per_page through the params' do
-        expect(Search.new(per_page: '3').per_page).to eq 3
+        expect(described_class.new(per_page: '3').per_page).to eq 3
       end
     end
 
     describe '#sort' do
       it 'returns the field to sort on' do
-        expect(Search.new(sort: 'content_partner').sort).to eq 'content_partner'
+        expect(described_class.new(sort: 'content_partner').sort).to eq 'content_partner'
       end
 
       it 'returns nil when not set' do
-        expect(Search.new.sort).to be nil
+        expect(described_class.new.sort).to be nil
       end
     end
 
     describe '#direction' do
       it 'returns the direction to sort the results' do
-        expect(Search.new(direction: 'asc').direction).to eq 'asc'
+        expect(described_class.new(direction: 'asc').direction).to eq 'asc'
       end
 
       it 'returns nil when not set' do
-        expect(Search.new.direction).to be nil
+        expect(described_class.new.direction).to be nil
       end
     end
 
     describe '#search_attributes' do
       it 'sets the filter defined in Supplejack.search_attributes with its current value' do
-        allow(Supplejack).to receive(:search_attributes) { [:location] }
+        allow(Supplejack).to receive(:search_attributes).and_return([:location])
 
-        expect(Search.new(i: { location: 'Wellington' }).location).to eq 'Wellington'
+        expect(described_class.new(i: { location: 'Wellington' }).location).to eq 'Wellington'
       end
     end
 
@@ -101,26 +101,26 @@ module Supplejack
       let(:filters) { { location: 'Wellington', country: 'New Zealand' } }
 
       it 'returns filters in a array format by default' do
-        expect(Search.new(i: filters).filters).to include([:location, 'Wellington'], [:country, 'New Zealand'])
+        expect(described_class.new(i: filters).filters).to include([:location, 'Wellington'], [:country, 'New Zealand'])
       end
 
       it 'returns a hash of the current search filters' do
-        expect(Search.new(i: filters).filters(format: :hash)).to include(filters)
+        expect(described_class.new(i: filters).filters(format: :hash)).to include(filters)
       end
 
       it 'expands filters that contain arrays' do
         filters = { location: %w[Wellington Auckland] }
-        expect(Search.new(i: filters).filters).to include([:location, 'Wellington'], [:location, 'Auckland'])
+        expect(described_class.new(i: filters).filters).to include([:location, 'Wellington'], [:location, 'Auckland'])
       end
 
       it 'removes the location filter' do
         filters = { location: %w[Wellington Auckland] }
-        expect(Search.new(i: filters).filters(except: [:location])).not_to include([:location, 'Wellington'], [:location, 'Auckland'])
+        expect(described_class.new(i: filters).filters(except: [:location])).not_to include([:location, 'Wellington'], [:location, 'Auckland'])
       end
     end
 
     describe '#facets' do
-      let(:search) { Search.new }
+      let(:search) { described_class.new }
       let(:facets_hash) { { 'location' => { 'Wellington' => 100 }, 'mayor' => { 'Brake, Brian' => 20 } } }
 
       before do
@@ -148,14 +148,14 @@ module Supplejack
       end
 
       it 'orders the facets based on the order set in the initializer' do
-        allow(Supplejack).to receive(:facets) { %i[mayor location] }
+        allow(Supplejack).to receive(:facets).and_return(%i[mayor location])
 
         expect(search.facets.first.name).to eq 'mayor'
         expect(search.facets.last.name).to eq 'location'
       end
 
       it 'orders the facets the other way around' do
-        allow(Supplejack).to receive(:facets) { %i[location mayor] }
+        allow(Supplejack).to receive(:facets).and_return(%i[location mayor])
 
         expect(search.facets.first.name).to eq 'location'
         expect(search.facets.last.name).to eq 'mayor'
@@ -167,7 +167,7 @@ module Supplejack
     end
 
     describe '#facet' do
-      let(:search) { Search.new }
+      let(:search) { described_class.new }
 
       it 'returns the specified facet' do
         facet = Supplejack::Facet.new('collection', [])
@@ -177,7 +177,7 @@ module Supplejack
       end
 
       it 'returns nil when facet is not found' do
-        allow(search).to receive(:facets) { [] }
+        allow(search).to receive(:facets).and_return([])
 
         expect(search.facet('collection')).to be nil
       end
@@ -191,7 +191,7 @@ module Supplejack
     end
 
     describe '#facet_pivots' do
-      let(:search) { Search.new }
+      let(:search) { described_class.new }
 
       it 'returns empty array when there are no facet pivots' do
         search.instance_variable_set(:@response, 'search' => {})
@@ -206,24 +206,17 @@ module Supplejack
       end
 
       it 'returns facet_pivots correct when there are facet pivots' do
-        search.instance_variable_set(:@response, 'search' => { facet_pivots:
-          {
-            'display_collection_s' =>
-              [
-                {
-                  'field' => 'display_collection_s',
-                  'value' => 'Auckland Libraries Heritage Images Collection',
-                  'count' => 26
-                }
-              ]
-          } })
+        search.instance_variable_set(
+          :@response,
+          'search' => { facet_pivots: { 'display_collection_s' => [{ 'field' => 'display_collection_s', 'value' => 'Auckland Libraries Heritage Images Collection', 'count' => 26 }] } }
+        )
 
-        expect(search.facet_pivots).to_not eq []
+        expect(search.facet_pivots).not_to eq []
       end
     end
 
     describe '#total' do
-      let(:search) { Search.new }
+      let(:search) { described_class.new }
 
       before { search.instance_variable_set(:@response, 'search' => { 'result_count' => 100 }) }
 
@@ -245,7 +238,7 @@ module Supplejack
     end
 
     describe '#results' do
-      let(:search)  { Search.new }
+      let(:search)  { described_class.new }
       let(:record1) { { 'id' => 1, 'title' => 'Wellington' } }
       let(:record2) { { 'id' => 2, 'title' => 'Auckland' } }
 
@@ -255,7 +248,7 @@ module Supplejack
       end
 
       it 'executes the request only once' do
-        allow(search).to receive(:total) { 10 }
+        allow(search).to receive(:total).and_return(10)
 
         expect(search).to receive(:execute_request).once
 
@@ -271,7 +264,7 @@ module Supplejack
       end
 
       it 'initializes record objects with the class provided in the params' do
-        search = Search.new(record_klass: 'test_item')
+        search = described_class.new(record_klass: 'test_item')
         search.instance_variable_set(:@response, 'search' => { 'results' => [record1, record2] })
 
         expect(TestItem).to receive(:new).with(record1)
@@ -296,12 +289,12 @@ module Supplejack
     end
 
     describe '#counts' do
-      let(:search) { Search.new }
+      let(:search) { described_class.new }
 
-      before { allow(search).to receive(:fetch_counts) { { 'images' => 100 } } }
+      before { allow(search).to receive(:fetch_counts).and_return({ 'images' => 100 }) }
 
-      context 'caching disabled' do
-        before { allow(Supplejack).to receive(:enable_caching) { false } }
+      context 'when caching is disabled' do
+        before { allow(Supplejack).to receive(:enable_caching).and_return(false) }
 
         it 'fetches the counts' do
           query_params = { 'images' => { category: 'Images' } }
@@ -315,7 +308,7 @@ module Supplejack
 
     describe '#fetch_counts' do
       context 'without filters' do
-        let(:search) { Search.new }
+        let(:search) { described_class.new }
 
         it 'returns a hash with row names and its values' do
           allow(search).to receive(:get).and_return('search' => { 'facets' => { 'counts' => { 'images' => 151_818 } } })
@@ -339,7 +332,7 @@ module Supplejack
 
     describe '#counts_params' do
       context 'without filters' do
-        let(:search) { Search.new }
+        let(:search) { described_class.new }
 
         it 'requests record_type == all' do
           query_parameters = { headings: { record_type: '1' } }
@@ -375,14 +368,14 @@ module Supplejack
         end
 
         it 'passes the text when present' do
-          search = Search.new(text: 'dogs')
+          search = described_class.new(text: 'dogs')
 
           expect(search.counts_params({})).to include(text: 'dogs')
         end
 
         it 'merges the :i and :il filters with record_type 0' do
           query_parameters = { images: { 'creator' => 'all', 'record_type' => '0' }, headings: { 'record_type' => '1', :dc_type => 'Group' } }
-          search = Search.new(i: { category: 'Images' }, il: { year: '1998' })
+          search = described_class.new(i: { category: 'Images' }, il: { year: '1998' })
 
           images_query = { creator: 'all', record_type: '0', category: 'Images', year: '1998' }
           headings_query = { record_type: '1', dc_type: 'Group' }
@@ -392,7 +385,7 @@ module Supplejack
 
         it 'merges *_text fields' do
           query_parameters = { images: { 'creator' => 'all', 'record_type' => '0' } }
-          search = Search.new(i: { subject_text: 'dog' })
+          search = described_class.new(i: { subject_text: 'dog' })
 
           images_query = { creator: 'all', record_type: '0' }
 
@@ -401,7 +394,7 @@ module Supplejack
       end
 
       context 'with active filters' do
-        let(:search) { Search.new(i: { location: 'Wellington' }) }
+        let(:search) { described_class.new(i: { location: 'Wellington' }) }
 
         it 'merges the existing filters into every facet query' do
           query_parameters = { images: { 'creator' => 'all', 'record_type' => 0 } }
@@ -418,7 +411,7 @@ module Supplejack
         end
 
         it 'overrides the record_type' do
-          search = Search.new(record_type: '1')
+          search = described_class.new(record_type: '1')
           query_parameters = { images: { 'record_type' => '0' } }
           expected_filters = { images: { record_type: '0' } }
 
@@ -426,7 +419,7 @@ module Supplejack
         end
 
         it 'merges existing negative filters' do
-          search = Search.new(i: { '-category' => 'Groups' })
+          search = described_class.new(i: { '-category' => 'Groups' })
           query_parameters = { photos: { 'has_large_thumbnail_url' => 'Y' } }
           expected_filters = { photos: { has_large_thumbnail_url: 'Y', '-category'.to_sym => 'Groups' } }
 
@@ -434,7 +427,7 @@ module Supplejack
         end
 
         it 'adds per_page params if present' do
-          search = Search.new(per_page: 0)
+          search = described_class.new(per_page: 0)
 
           expect(search.counts_params({})).to include(per_page: 0)
         end
@@ -442,7 +435,7 @@ module Supplejack
     end
 
     describe '#request_path' do
-      let(:search) { Search.new }
+      let(:search) { described_class.new }
 
       it 'returns /records by default' do
         expect(search.request_path).to eq '/records'
@@ -450,7 +443,7 @@ module Supplejack
     end
 
     describe '#execute_request' do
-      let(:search) { Search.new }
+      let(:search) { described_class.new }
 
       it 'only executes the request once' do
         expect(search).to receive(:get).once.and_return('{}')
@@ -489,7 +482,7 @@ module Supplejack
         expect(search.execute_request).to eq('search' => {})
       end
 
-      context 'error handling' do
+      context 'when api returns and error' do
         it 'raises a timeout error' do
           allow(search).to receive(:get).and_raise(RestClient::Exceptions::ReadTimeout)
 
@@ -509,17 +502,17 @@ module Supplejack
         end
       end
 
-      context 'caching enabled' do
-        let(:cache) { double(:cache).as_null_object }
+      context 'when caching is enabled' do
+        let(:cache) { instance_double(ActiveSupport::Cache::Store).as_null_object }
 
         before do
           allow(Rails).to receive(:cache) { cache }
-          allow(Supplejack).to receive(:enable_caching) { true }
+          allow(Supplejack).to receive(:enable_caching).and_return(true)
         end
 
         it 'caches the response when it is cacheable' do
-          search = Supplejack::Search.new
-          allow(search).to receive(:cacheable?) { true }
+          search = described_class.new
+          allow(search).to receive(:cacheable?).and_return(true)
           cache_key = Digest::MD5.hexdigest("/records?#{search.api_params.to_query}")
 
           expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 1.hour)
@@ -528,8 +521,8 @@ module Supplejack
         end
 
         it 'doesnt cache the response it is not cacheable' do
-          search = Supplejack::Search.new(text: 'dogs')
-          allow(search).to receive(:cacheable?) { false }
+          search = described_class.new(text: 'dogs')
+          allow(search).to receive(:cacheable?).and_return(false)
           expect(Rails.cache).not_to receive(:fetch)
 
           search.execute_request
@@ -539,20 +532,20 @@ module Supplejack
 
     describe '#cacheable?' do
       it 'returns true when it doesn\'t have a text parameter' do
-        expect(Supplejack::Search.new.cacheable?).to be true
+        expect(described_class.new.cacheable?).to be true
       end
 
       it 'returns false when it has a text parameter' do
-        expect(Supplejack::Search.new(text: 'Dogs').cacheable?).to be false
+        expect(described_class.new(text: 'Dogs').cacheable?).to be false
       end
 
       it 'returns false then it\'s not the first page of results' do
-        expect(Supplejack::Search.new(page: '2').cacheable?).to be false
+        expect(described_class.new(page: '2').cacheable?).to be false
       end
     end
 
     describe '#has_attribute_name?' do
-      let(:search) { Search.new }
+      let(:search) { described_class.new }
 
       before { search.location = %w[Wellington Auckland] }
 
@@ -564,8 +557,8 @@ module Supplejack
         expect(search.has_location?('Videos')).to be false
       end
 
-      context 'search filter is single valued' do
-        let(:search) { Search.new }
+      context 'when search filter is single valued' do
+        let(:search) { described_class.new }
 
         before { search.location = 'Wellington' }
 
@@ -583,8 +576,8 @@ module Supplejack
           expect(search.has_category?('Cats')).to be nil
         end
 
-        it 'shouldn\'t search for a non existent search attribute' do
-          allow(Supplejack).to receive(:search_attributes) { [] }
+        it 'search for onlu existent search attribute' do
+          allow(Supplejack).to receive(:search_attributes).and_return([])
 
           expect(search).not_to receive(:filter_and_value?)
           search.has_category?('Cats')
@@ -593,20 +586,20 @@ module Supplejack
     end
 
     describe '#categories' do
-      let(:search) { Search.new(i: { category: 'Books', year: 2001 }, text: 'Dogs') }
+      let(:search) { described_class.new(i: { category: 'Books', year: 2001 }, text: 'Dogs') }
 
       before do
-        allow(search).to receive(:get) { { 'search' => { 'facets' => { 'category' => { 'Books' => 123 } }, 'result_count' => 123 } } }
+        allow(search).to receive(:get).and_return({ 'search' => { 'facets' => { 'category' => { 'Books' => 123 } }, 'result_count' => 123 } })
       end
 
-      it 'should call the fetch_values method' do
+      it 'calls the fetch_values method' do
         expect(search).to receive(:facet_values).with('category', {})
 
         search.categories
       end
 
       it 'removes category filter from the search request' do
-        expect(search).to receive(:get).with('/records', hash_including(and: { year: 2001 })).and_return('search' => { 'facets' => { 'category' => { 'Books' => 123 } } })
+        allow(search).to receive(:get).with('/records', hash_including(and: { year: 2001 })).and_return('search' => { 'facets' => { 'category' => { 'Books' => 123 } } })
 
         search.categories
       end
@@ -621,7 +614,7 @@ module Supplejack
         search.categories
       end
 
-      it 'should return add the All count to the hash' do
+      it 'returns add the All count to the hash' do
         expect(search.categories['All']).to eq 123
       end
 
@@ -633,10 +626,10 @@ module Supplejack
     end
 
     describe '#fetch_facet_values' do
-      let(:search) { Search.new(i: { category: 'Books', year: 2001 }, text: 'Dogs') }
+      let(:search) { described_class.new(i: { category: 'Books', year: 2001 }, text: 'Dogs') }
 
       before do
-        allow(search).to receive(:get) { { 'search' => { 'facets' => { 'category' => { 'Books' => 123, 'Images' => 100 } }, 'result_count' => 123 } } }
+        allow(search).to receive(:get).and_return({ 'search' => { 'facets' => { 'category' => { 'Books' => 123, 'Images' => 100 } }, 'result_count' => 123 } })
       end
 
       it 'returns the category facet hash' do
@@ -649,7 +642,7 @@ module Supplejack
         expect(search.fetch_facet_values('category')).to eq('All' => 0)
       end
 
-      it 'should add the All count to the hash with the sum of all facets' do
+      it 'adds the All count to the hash with the sum of all facets' do
         expect(search.fetch_facet_values('category')['All']).to eq 223
       end
 
@@ -664,7 +657,7 @@ module Supplejack
         search.fetch_facet_values('category')
       end
 
-      context 'sorting' do
+      context 'when sorting' do
         before do
           @facet = Supplejack::Facet.new('category', 'All' => 223, 'Books' => 123, 'Images' => 100)
           allow(Supplejack::Facet).to receive(:new) { @facet }
@@ -691,7 +684,7 @@ module Supplejack
     end
 
     describe 'facet_values_params' do
-      let(:search) { Search.new(i: { type: 'Person', year: 2001 }, text: 'Dogs') }
+      let(:search) { described_class.new(i: { type: 'Person', year: 2001 }, text: 'Dogs') }
 
       it 'removes type filter from the search request' do
         expect(search.facet_values_params('type')).to include(and: { year: 2001 })
@@ -702,54 +695,54 @@ module Supplejack
       end
 
       it 'adds without filters' do
-        search = Search.new(i: { :type => 'Person', :year => 2001, '-group' => 'Group' }, text: 'Dogs')
+        search = described_class.new(i: { :type => 'Person', :year => 2001, '-group' => 'Group' }, text: 'Dogs')
 
         expect(search.facet_values_params('type')).to include(without: { group: 'Group' })
       end
 
       it 'only adds the and_filters to :and' do
-        search = Search.new(i: { :type => 'Person', :year => 2001, '-group' => 'Group' }, text: 'Dogs')
+        search = described_class.new(i: { :type => 'Person', :year => 2001, '-group' => 'Group' }, text: 'Dogs')
 
         expect(search.facet_values_params('type')).to include(and: { year: 2001 })
       end
 
       it 'gets the facet_values for a record_type 1' do
-        search = Search.new(i: { type: 'Person' }, h: { group: 'Group' }, text: 'Dogs', record_type: 1)
+        search = described_class.new(i: { type: 'Person' }, h: { group: 'Group' }, text: 'Dogs', record_type: 1)
 
         expect(search.facet_values_params('group')).to include(and: {})
       end
 
       it 'restricts results to filters specified in without accessor' do
-        search = Search.new
+        search = described_class.new
         search.without = { website: 'Flickr' }
 
         expect(search.facet_values_params('type')).to include(without: { website: 'Flickr' })
       end
 
       it 'merges in the filters specified in without' do
-        search = Search.new(i: { '-type' => 'Person' })
+        search = described_class.new(i: { '-type' => 'Person' })
         search.without = { website: 'Flickr' }
 
         expect(search.facet_values_params('type')).to include(without: { website: 'Flickr', type: 'Person' })
       end
 
       it 'adds the restrictions set in the and variable' do
-        search = Search.new
+        search = described_class.new
         search.and = { content_partner: 'NLNZ' }
 
         expect(search.facet_values_params('type')).to include(and: { content_partner: 'NLNZ' })
       end
 
       it 'adds the restrictions set in the or variable' do
-        search = Search.new
+        search = described_class.new
         search.or = { content_partner: 'NLNZ' }
 
         expect(search.facet_values_params('type')).to include(or: { content_partner: 'NLNZ' })
       end
 
       it 'memoizes the params' do
-        search = Search.new
-        expect(search).to receive(:url_format).once.and_return(double(:url_format, and_filters: {}))
+        search = described_class.new
+        expect(search).to receive(:url_format).once.and_return(instance_double(Supplejack::UrlFormats::ItemHash, and_filters: {}))
 
         search.facet_values_params('type')
         search.facet_values_params('type')
@@ -761,16 +754,12 @@ module Supplejack
     end
 
     describe '#facet_values' do
-      let(:search) { Search.new }
+      let(:search) { described_class.new }
 
-      before do
-        allow(search).to receive(:fetch_facet_values) { { 'Books' => 100 } }
-      end
+      before { allow(search).to receive(:fetch_facet_values).and_return({ 'Books' => 100 }) }
 
-      context 'caching disabled' do
-        before do
-          allow(Supplejack).to receive(:enable_caching) { false }
-        end
+      context 'when caching is disabled' do
+        before { allow(Supplejack).to receive(:enable_caching).and_return(false) }
 
         it 'fetches the facet values' do
           expect(search).to receive(:fetch_facet_values).with('category', anything)
@@ -781,7 +770,7 @@ module Supplejack
     end
 
     describe '#merge_extra_filters' do
-      let(:search) { Search.new }
+      let(:search) { described_class.new }
 
       it 'merges the and filters' do
         search.and = { type: 'Person' }

--- a/spec/supplejack/search_spec.rb
+++ b/spec/supplejack/search_spec.rb
@@ -14,98 +14,88 @@ end
 # rubocop:disable Metrics/ModuleLength
 module Supplejack
   describe Search do
-    describe '#initalize' do
-      it 'doesn\'t break when initalized with nil' do
-        Search.new(nil)
-      end
-    end
-
     describe '#params' do
       it 'defaults to facets set in initializer' do
-        Supplejack.stub(:facets) { %w[location description] }
-        Search.new.api_params[:facets].should eq('location,description')
+        allow(Supplejack).to receive(:facets) { %w[location description] }
+
+        expect(Search.new.api_params[:facets]).to eq('location,description')
       end
 
       it 'sets the facets through the params' do
-        Search.new(facets: 'name,description').api_params[:facets].should eq('name,description')
+        expect(Search.new(facets: 'name,description').api_params[:facets]).to eq('name,description')
       end
 
       it 'defaults to facets_per_page set in initializer' do
-        Supplejack.stub(:facets_per_page) { 33 }
-        Search.new.api_params[:facets_per_page].should eq 33
+        allow(Supplejack).to receive(:facets_per_page) { 33 }
+
+        expect(Search.new.api_params[:facets_per_page]).to eq 33
       end
 
       it 'sets the facets_per_page through the params' do
-        Search.new(facets_per_page: 13).api_params[:facets_per_page].should eq 13
+        expect(Search.new(facets_per_page: 13).api_params[:facets_per_page]).to eq 13
       end
 
       it 'deletes rails specific params' do
         params = Search.new(controller: 'records', action: 'index').api_params
-        params.should_not have_key(:controller)
-        params.should_not have_key(:action)
+
+        expect(params).not_to have_key(:controller)
+        expect(params).not_to have_key(:action)
       end
     end
 
     describe '#text' do
       it 'returns the search text' do
-        Search.new(text: 'dog').text.should eq('dog')
+        expect(Search.new(text: 'dog').text).to eq('dog')
       end
     end
 
-    # describe '#geo_bbox' do
-    # end
-
-    # describe "#record_type" do
-    # end
-
     describe '#page' do
       it 'defaults to 1' do
-        Search.new.page.should eq 1
+        expect(Search.new.page).to eq 1
       end
 
       it 'converts the page to a number' do
-        Search.new(page: '2').page.should eq 2
+        expect(Search.new(page: '2').page).to eq 2
       end
     end
 
     describe '#per_page' do
       it 'defaults to the per_page in the initializer' do
-        Supplejack.stub(:per_page) { 16 }
-        Search.new.per_page.should eq 16
+        allow(Supplejack).to receive(:per_page) { 16 }
+
+        expect(Search.new.per_page).to eq 16
       end
 
       it 'sers the per_page through the params' do
-        Search.new(per_page: '3').per_page.should eq 3
+        expect(Search.new(per_page: '3').per_page).to eq 3
       end
     end
 
     describe '#sort' do
       it 'returns the field to sort on' do
-        Search.new(sort: 'content_partner').sort.should eq 'content_partner'
+        expect(Search.new(sort: 'content_partner').sort).to eq 'content_partner'
       end
 
       it 'returns nil when not set' do
-        Search.new.sort.should be_nil
+        expect(Search.new.sort).to be nil
       end
     end
 
     describe '#direction' do
       it 'returns the direction to sort the results' do
-        Search.new(direction: 'asc').direction.should eq 'asc'
+        expect(Search.new(direction: 'asc').direction).to eq 'asc'
       end
 
       it 'returns nil when not set' do
-        Search.new.direction.should be_nil
+        expect(Search.new.direction).to be nil
       end
     end
 
-    # describe "#custom_search" do
-    # end
-
     describe '#search_attributes' do
       it 'sets the filter defined in Supplejack.search_attributes with its current value' do
-        Supplejack.stub(:search_attributes) { [:location] }
-        Search.new(i: { location: 'Wellington' }).location.should eq 'Wellington'
+        allow(Supplejack).to receive(:search_attributes) { [:location] }
+
+        expect(Search.new(i: { location: 'Wellington' }).location).to eq 'Wellington'
       end
     end
 
@@ -115,21 +105,21 @@ module Supplejack
       end
 
       it 'returns filters in a array format by default' do
-        Search.new(i: @filters).filters.should include([:location, 'Wellington'], [:country, 'New Zealand'])
+        expect(Search.new(i: @filters).filters).to include([:location, 'Wellington'], [:country, 'New Zealand'])
       end
 
       it 'returns a hash of the current search filters' do
-        Search.new(i: @filters).filters(format: :hash).should include(@filters)
+        expect(Search.new(i: @filters).filters(format: :hash)).to include(@filters)
       end
 
       it 'expands filters that contain arrays' do
         @filters = { location: %w[Wellington Auckland] }
-        Search.new(i: @filters).filters.should include([:location, 'Wellington'], [:location, 'Auckland'])
+        expect(Search.new(i: @filters).filters).to include([:location, 'Wellington'], [:location, 'Auckland'])
       end
 
       it 'removes the location filter' do
         @filters = { location: %w[Wellington Auckland] }
-        Search.new(i: @filters).filters(except: [:location]).should_not include([:location, 'Wellington'], [:location, 'Auckland'])
+        expect(Search.new(i: @filters).filters(except: [:location])).not_to include([:location, 'Wellington'], [:location, 'Auckland'])
       end
     end
 
@@ -142,67 +132,69 @@ module Supplejack
       end
 
       it 'executes the request only once' do
-        @search.should_receive(:execute_request).once
+        expect(@search).to receive(:execute_request).once
+
         @search.facets
         @search.facets
       end
 
       it 'handles a failed request from the API' do
         @search.instance_variable_set(:@response, 'search' => {})
-        @search.facets.should be_empty
+        expect(@search.facets.empty?).to be true
       end
 
       it 'initializes a facet object for each facet' do
-        Supplejack::Facet.should_receive(:new).with('location', 'Wellington' => 100)
-        Supplejack::Facet.should_receive(:new).with('mayor', 'Brake, Brian' => 20)
+        expect(Supplejack::Facet).to receive(:new).with('location', 'Wellington' => 100)
+        expect(Supplejack::Facet).to receive(:new).with('mayor', 'Brake, Brian' => 20)
+
         @search.facets
       end
 
       it 'orders the facets based on the order set in the initializer' do
-        Supplejack.stub(:facets) { %i[mayor location] }
-        @search.facets.first.name.should eq 'mayor'
-        @search.facets.last.name.should eq 'location'
+        allow(Supplejack).to receive(:facets) { %i[mayor location] }
+
+        expect(@search.facets.first.name).to eq 'mayor'
+        expect(@search.facets.last.name).to eq 'location'
       end
 
       it 'orders the facets the other way around' do
-        Supplejack.stub(:facets) { %i[location mayor] }
-        @search.facets.first.name.should eq 'location'
-        @search.facets.last.name.should eq 'mayor'
+        allow(Supplejack).to receive(:facets) { %i[location mayor] }
+
+        expect(@search.facets.first.name).to eq 'location'
+        expect(@search.facets.last.name).to eq 'mayor'
       end
 
       it 'returns the facet values' do
-        @search.facets.first.values.should eq('Wellington' => 100)
+        expect(@search.facets.first.values).to eq('Wellington' => 100)
       end
     end
 
     describe '#facet' do
-      before(:each) do
-        @search = Search.new
-      end
+      before { @search = Search.new }
 
       it 'returns the specified facet' do
         facet = Supplejack::Facet.new('collection', [])
-        @search.stub(:facets) { [facet] }
+        allow(@search).to receive(:facets) { [facet] }
 
-        @search.facet('collection').should eq facet
+        expect(@search.facet('collection')).to eq facet
       end
 
       it 'returns nil when facet is not found' do
-        @search.stub(:facets) { [] }
-        @search.facet('collection').should be_nil
+        allow(@search).to receive(:facets) { [] }
+
+        expect(@search.facet('collection')).to be nil
       end
 
       it 'returns nil if value is nil' do
         facet = Supplejack::Facet.new('collection', [])
-        @search.stub(:facets) { [facet] }
-        @search.facet(nil).should be_nil
+        allow(@search).to receive(:facets) { [facet] }
+
+        expect(@search.facet(nil)).to be nil
       end
     end
 
     describe '#facet_pivots' do
-      before(:each) do
-        @search = Search.new
-      end
+      before { @search = Search.new }
 
       it 'returns empty array when there are no facet pivots' do
         @search.instance_variable_set(:@response, 'search' => {})
@@ -240,24 +232,26 @@ module Supplejack
       end
 
       it 'executes the request only once' do
-        @search.should_receive(:execute_request).once
+        expect(@search).to receive(:execute_request).once
         @search.total
         @search.total
       end
 
       it 'returns the total from the response' do
-        @search.total.should eq 100
+        expect(@search.total).to eq 100
       end
 
       it 'returns 0 when the request to the API failed' do
         @search.instance_variable_set(:@response, 'search' => {})
-        @search.total.should eq 0
+
+        expect(@search.total).to eq 0
       end
     end
 
     describe '#results' do
       before(:each) do
-        Supplejack.stub(:record_klass).and_return('TestRecord')
+        allow(Supplejack).to receive(:record_klass).and_return('TestRecord')
+
         @search = Search.new
         @record1 = { 'id' => 1, 'title' => 'Wellington' }
         @record2 = { 'id' => 2, 'title' => 'Auckland' }
@@ -265,54 +259,63 @@ module Supplejack
       end
 
       it 'executes the request only once' do
-        @search.stub(:total) { 10 }
-        @search.should_receive(:execute_request).once
+        allow(@search).to receive(:total) { 10 }
+
+        expect(@search).to receive(:execute_request).once
+
         @search.results
         @search.results
       end
 
       it 'initializes record objects with the default class' do
-        TestRecord.should_receive(:new).with(@record1)
-        TestRecord.should_receive(:new).with(@record2)
+        expect(TestRecord).to receive(:new).with(@record1)
+        expect(TestRecord).to receive(:new).with(@record2)
+
         @search.results
       end
 
       it 'initializes record objects with the class provided in the params' do
         @search = Search.new(record_klass: 'test_item')
         @search.instance_variable_set(:@response, 'search' => { 'results' => [@record1, @record2] })
-        TestItem.should_receive(:new).with(@record1)
-        TestItem.should_receive(:new).with(@record2)
+
+        expect(TestItem).to receive(:new).with(@record1)
+        expect(TestItem).to receive(:new).with(@record2)
+
         @search.results
       end
 
       it 'returns a array of objects of the provided class' do
-        @search.results.first.class.should eq TestRecord
+        expect(@search.results.first.class).to eq TestRecord
       end
 
       it 'returns an array wraped in paginated collection object' do
-        @search.results.current_page.should eq 1
+        expect(@search.results.current_page).to eq 1
       end
 
       it 'returns empty paginated collection when API request failed' do
         @search.instance_variable_set(:@response, 'search' => {})
-        @search.results.size.should eq 0
+
+        expect(@search.results.size).to eq 0
       end
     end
 
     describe '#counts' do
       before(:each) do
         @search = Search.new
-        @search.stub(:fetch_counts) { { 'images' => 100 } }
+
+        allow(@search).to receive(:fetch_counts) { { 'images' => 100 } }
       end
 
       context 'caching disabled' do
         before(:each) do
-          Supplejack.stub(:enable_caching) { false }
+          allow(Supplejack).to receive(:enable_caching) { false }
         end
 
         it 'fetches the counts' do
           query_params = { 'images' => { category: 'Images' } }
-          @search.should_receive(:fetch_counts).with(query_params)
+
+          expect(@search).to receive(:fetch_counts).with(query_params)
+
           @search.counts(query_params)
         end
       end
@@ -320,70 +323,70 @@ module Supplejack
 
     describe '#fetch_counts' do
       context 'without filters' do
-        before(:each) do
-          @search = Search.new
-        end
+        before { @search = Search.new }
 
         it 'returns a hash with row names and its values' do
-          @search.stub(:get).and_return('search' => { 'facets' => { 'counts' => { 'images' => 151_818 } } })
-          @search.fetch_counts({}).should eq('images' => 151_818)
+          allow(@search).to receive(:get).and_return('search' => { 'facets' => { 'counts' => { 'images' => 151_818 } } })
+
+          expect(@search.fetch_counts({})).to eq('images' => 151_818)
         end
 
         it 'returns every count even when there are no results matching' do
-          @search.stub(:get).and_return('search' => { 'facets' => { 'counts' => { 'images' => 151_818 } } })
-          @search.fetch_counts(images: {}, headings: {}).should eq('images' => 151_818, 'headings' => 0)
+          allow(@search).to receive(:get).and_return('search' => { 'facets' => { 'counts' => { 'images' => 151_818 } } })
+
+          expect(@search.fetch_counts(images: {}, headings: {})).to eq('images' => 151_818, 'headings' => 0)
         end
 
         it 'returns 0 for every facet when the API response fails' do
-          @search.stub(:get).and_raise(StandardError)
-          @search.fetch_counts(images: {}).should eq('images' => 0)
+          allow(@search).to receive(:get).and_raise(StandardError)
+
+          expect(@search.fetch_counts(images: {})).to eq('images' => 0)
         end
       end
     end
 
     describe '#counts_params' do
       context 'without filters' do
-        before(:each) do
-          @search = Search.new
-        end
+        before { @search = Search.new }
 
         it 'requests record_type == all' do
           query_parameters = { headings: { record_type: '1' } }
-          @search.counts_params(query_parameters).should include(facet_query: query_parameters, record_type: 'all')
+
+          expect(@search.counts_params(query_parameters)).to include(facet_query: query_parameters, record_type: 'all')
         end
 
         it 'adds the restrictions set in the without variable' do
           query_parameters = { headings: { record_type: '1' } }
           @search.without = { location: 'Wellington' }
-          @search.counts_params(query_parameters).should include(without: { location: 'Wellington' })
+
+          expect(@search.counts_params(query_parameters)).to include(without: { location: 'Wellington' })
         end
 
         it 'restricts the result set to only ones that match the and filters' do
           query_parameters = { headings: { record_type: '1' } }
           @search.and = { location: 'Wellington' }
-          @search.counts_params(query_parameters).should include(and: { location: 'Wellington' })
+
+          expect(@search.counts_params(query_parameters)).to include(and: { location: 'Wellington' })
         end
 
         it 'restricts the result set to results that match any of the or filters' do
           query_parameters = { headings: { record_type: '1' } }
           @search.or = { location: %w[Wellington Auckland] }
-          @search.counts_params(query_parameters).should include(or: { location: %w[Wellington Auckland] })
+
+          expect(@search.counts_params(query_parameters)).to include(or: { location: %w[Wellington Auckland] })
         end
 
         it 'executes a request with facet_queries' do
           query_parameters = { images: { creator: 'all', record_type: '0' }, headings: { record_type: '1' } }
-          @search.counts_params(query_parameters).should include(facet_query: query_parameters)
+
+          expect(@search.counts_params(query_parameters)).to include(facet_query: query_parameters)
         end
 
         it 'passes the text when present' do
           @search = Search.new(text: 'dogs')
-          @search.counts_params({}).should include(text: 'dogs')
-        end
 
-        # it 'passes the geo_bbox when present' do
-        #   @search = Search.new(geo_bbox: '1,2,3,4')
-        #   @search.counts_params({}).should include(geo_bbox: '1,2,3,4')
-        # end
+          expect(@search.counts_params({})).to include(text: 'dogs')
+        end
 
         it 'merges the :i and :il filters with record_type 0' do
           query_parameters = { images: { 'creator' => 'all', 'record_type' => '0' }, headings: { 'record_type' => '1', :dc_type => 'Group' } }
@@ -392,7 +395,7 @@ module Supplejack
           images_query = { creator: 'all', record_type: '0', category: 'Images', year: '1998' }
           headings_query = { record_type: '1', dc_type: 'Group' }
 
-          @search.counts_params(query_parameters).should include(facet_query: { images: images_query, headings: headings_query })
+          expect(@search.counts_params(query_parameters)).to include(facet_query: { images: images_query, headings: headings_query })
         end
 
         it 'merges *_text fields' do
@@ -401,90 +404,97 @@ module Supplejack
 
           images_query = { creator: 'all', record_type: '0' }
 
-          @search.counts_params(query_parameters).should include(text: 'dog', query_fields: [:subject], facet_query: { images: images_query })
+          expect(@search.counts_params(query_parameters)).to include(text: 'dog', query_fields: [:subject], facet_query: { images: images_query })
         end
       end
 
       context 'with active filters' do
-        before(:each) do
-          @search = Search.new(i: { location: 'Wellington' })
-        end
+        before { @search = Search.new(i: { location: 'Wellington' }) }
 
         it 'merges the existing filters into every facet query' do
           query_parameters = { images: { 'creator' => 'all', 'record_type' => 0 } }
           expected_filters = { images: { creator: 'all', location: 'Wellington', record_type: 0 } }
-          @search.counts_params(query_parameters).should include(facet_query: expected_filters)
+
+          expect(@search.counts_params(query_parameters)).to include(facet_query: expected_filters)
         end
 
         it 'merges existing filters without overriding' do
           query_parameters = { images: { 'location' => 'Matapihi', 'record_type' => 0 } }
           expected_filters = { images: { location: %w[Wellington Matapihi], record_type: 0 } }
-          @search.counts_params(query_parameters).should include(facet_query: expected_filters)
+
+          expect(@search.counts_params(query_parameters)).to include(facet_query: expected_filters)
         end
 
         it 'overrides the record_type' do
           @search = Search.new(record_type: '1')
           query_parameters = { images: { 'record_type' => '0' } }
           expected_filters = { images: { record_type: '0' } }
-          @search.counts_params(query_parameters).should include(facet_query: expected_filters)
+
+          expect(@search.counts_params(query_parameters)).to include(facet_query: expected_filters)
         end
 
         it 'merges existing negative filters' do
           @search = Search.new(i: { '-category' => 'Groups' })
           query_parameters = { photos: { 'has_large_thumbnail_url' => 'Y' } }
           expected_filters = { photos: { has_large_thumbnail_url: 'Y', '-category'.to_sym => 'Groups' } }
-          @search.counts_params(query_parameters).should include(facet_query: expected_filters)
+
+          expect(@search.counts_params(query_parameters)).to include(facet_query: expected_filters)
         end
 
         it 'adds per_page params if present' do
           @search = Search.new(per_page: 0)
-          @search.counts_params({}).should include(per_page: 0)
+
+          expect(@search.counts_params({})).to include(per_page: 0)
         end
       end
     end
 
     describe '#request_path' do
-      before(:each) do
-        @search = Search.new
-      end
+      before { @search = Search.new }
 
       it 'returns /records by default' do
-        @search.request_path.should eq '/records'
+        expect(@search.request_path).to eq '/records'
       end
     end
 
     describe '#execute_request' do
-      before(:each) do
-        @search = Search.new
-      end
+      before { @search = Search.new }
 
       it 'only executes the request once' do
-        @search.should_receive(:get).once.and_return('{}')
+        expect(@search).to receive(:get).once.and_return('{}')
+
         @search.execute_request
         @search.execute_request
       end
 
       it 'removes the results that match the without filters' do
         @search.without = { location: 'Wellington' }
-        @search.should_receive(:get).with('/records', hash_including(without: { location: 'Wellington' }))
+
+        expect(@search).to receive(:get).with('/records', hash_including(without: { location: 'Wellington' }))
+
         @search.execute_request
       end
 
       it 'restricts the result set to only ones that match the and filters' do
         @search.and = { location: 'Wellington' }
-        @search.should_receive(:get).with('/records', hash_including(and: { location: 'Wellington' }))
+
+        expect(@search).to receive(:get).with('/records', hash_including(and: { location: 'Wellington' }))
+
         @search.execute_request
       end
 
       it 'restricts the result set to only ones that match any of the or filters' do
         @search.or = { location: ['Wellington'] }
-        @search.should_receive(:get).with('/records', hash_including(or: { location: ['Wellington'] }))
+
+        expect(@search).to receive(:get).with('/records', hash_including(or: { location: ['Wellington'] }))
+
         @search.execute_request
       end
 
       it 'returns a empty search hash when a error is raised' do
-        @search.stub(:get).and_raise(StandardError)
-        @search.execute_request.should eq('search' => {})
+        allow(@search).to receive(:get).and_raise(StandardError)
+
+        expect(@search.execute_request).to eq('search' => {})
       end
 
       context 'error handling' do
@@ -503,31 +513,32 @@ module Supplejack
         it 'raises no error but returns an empty search' do
           allow(@search).to receive(:get).and_raise(StandardError)
 
-          # rubocop:disable Lint/ParenthesesAsGroupedExpression
-          expect(@search.execute_request).to eq ({ 'search' => {} })
-          # rubocop:enable Lint/ParenthesesAsGroupedExpression
+          expect(@search.execute_request).to eq('search' => {})
         end
       end
 
       context 'caching enabled' do
         before :each do
           @cache = double(:cache).as_null_object
-          Rails.stub(:cache) { @cache }
-          Supplejack.stub(:enable_caching) { true }
+          allow(Rails).to receive(:cache) { @cache }
+          allow(Supplejack).to receive(:enable_caching) { true }
         end
 
         it 'caches the response when it is cacheable' do
           search = Supplejack::Search.new
-          search.stub(:cacheable?) { true }
+          allow(search).to receive(:cacheable?) { true }
           cache_key = Digest::MD5.hexdigest("/records?#{search.api_params.to_query}")
-          Rails.cache.should_receive(:fetch).with(cache_key, expires_in: 1.hour)
+
+          expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 1.hour)
+
           search.execute_request
         end
 
         it 'doesnt cache the response it is not cacheable' do
           search = Supplejack::Search.new(text: 'dogs')
-          search.stub(:cacheable?) { false }
-          Rails.cache.should_not_receive(:fetch)
+          allow(search).to receive(:cacheable?) { false }
+          expect(Rails.cache).not_to receive(:fetch)
+
           search.execute_request
         end
       end
@@ -535,30 +546,30 @@ module Supplejack
 
     describe '#cacheable?' do
       it 'returns true when it doesn\'t have a text parameter' do
-        Supplejack::Search.new.cacheable?.should be_truthy
+        expect(Supplejack::Search.new.cacheable?).to be true
       end
 
       it 'returns false when it has a text parameter' do
-        Supplejack::Search.new(text: 'Dogs').cacheable?.should be_falsey
+        expect(Supplejack::Search.new(text: 'Dogs').cacheable?).to be false
       end
 
       it 'returns false then it\'s not the first page of results' do
-        Supplejack::Search.new(page: '2').cacheable?.should be_falsey
+        expect(Supplejack::Search.new(page: '2').cacheable?).to be false
       end
     end
 
     describe '#has_attribute_name?' do
-      before(:each) do
+      before do
         @search = Search.new
         @search.location = %w[Wellington Auckland]
       end
 
       it 'returns true if value is in filter' do
-        @search.has_location?('Wellington').should be_truthy
+        expect(@search.has_location?('Wellington')).to be true
       end
 
       it 'returns false is value is not in filter' do
-        @search.has_location?('Videos').should be_falsey
+        expect(@search.has_location?('Videos')).to be false
       end
 
       context 'search filter is single valued' do
@@ -568,21 +579,23 @@ module Supplejack
         end
 
         it 'returns true if value matches filter' do
-          @search.has_location?('Wellington').should be_truthy
+          expect(@search.has_location?('Wellington')).to be true
         end
 
         it 'returns false if value does not match the filter' do
-          @search.has_location?('Cats').should be_falsey
+          expect(@search.has_location?('Cats')).to be false
         end
 
         it 'returns false when location has nil value' do
           @search.location = nil
-          @search.has_category?('Cats').should be_falsey
+
+          expect(@search.has_category?('Cats')).to be nil
         end
 
         it 'shouldn\'t search for a non existent search attribute' do
-          Supplejack.stub(:search_attributes) { [] }
-          @search.should_not_receive(:filter_and_value?)
+          allow(Supplejack).to receive(:search_attributes) { [] }
+
+          expect(@search).not_to receive(:filter_and_value?)
           @search.has_category?('Cats')
         end
       end
@@ -591,34 +604,38 @@ module Supplejack
     describe '#categories' do
       before(:each) do
         @search = Search.new(i: { category: 'Books', year: 2001 }, text: 'Dogs')
-        @search.stub(:get) { { 'search' => { 'facets' => { 'category' => { 'Books' => 123 } }, 'result_count' => 123 } } }
+        allow(@search).to receive(:get) { { 'search' => { 'facets' => { 'category' => { 'Books' => 123 } }, 'result_count' => 123 } } }
       end
 
       it 'should call the fetch_values method' do
-        @search.should_receive(:facet_values).with('category', {})
+        expect(@search).to receive(:facet_values).with('category', {})
+
         @search.categories
       end
 
       it 'removes category filter from the search request' do
-        @search.should_receive(:get).with('/records', hash_including(and: { year: 2001 })).and_return('search' => { 'facets' => { 'category' => { 'Books' => 123 } } })
+        expect(@search).to receive(:get).with('/records', hash_including(and: { year: 2001 })).and_return('search' => { 'facets' => { 'category' => { 'Books' => 123 } } })
+
         @search.categories
       end
 
       it 'returns the category facet hash ' do
-        @search.categories.should include('Books' => 123)
+        expect(@search.categories).to include('Books' => 123)
       end
 
       it 'asks the API for 0 results' do
-        @search.should_receive(:get).with('/records', hash_including(per_page: 0))
+        expect(@search).to receive(:get).with('/records', hash_including(per_page: 0))
+
         @search.categories
       end
 
       it 'should return add the All count to the hash' do
-        @search.categories['All'].should eq 123
+        expect(@search.categories['All']).to eq 123
       end
 
       it 'orders the category values by :count' do
-        @search.should_receive(:facet_values).with('category', sort: :count)
+        expect(@search).to receive(:facet_values).with('category', sort: :count)
+
         @search.categories(sort: :count)
       end
     end
@@ -626,28 +643,30 @@ module Supplejack
     describe '#fetch_facet_values' do
       before(:each) do
         @search = Search.new(i: { category: 'Books', year: 2001 }, text: 'Dogs')
-        @search.stub(:get) { { 'search' => { 'facets' => { 'category' => { 'Books' => 123, 'Images' => 100 } }, 'result_count' => 123 } } }
+        allow(@search).to receive(:get) { { 'search' => { 'facets' => { 'category' => { 'Books' => 123, 'Images' => 100 } }, 'result_count' => 123 } } }
       end
 
       it 'returns the category facet hash' do
-        @search.fetch_facet_values('category').should include('Books' => 123)
+        expect(@search.fetch_facet_values('category')).to include('Books' => 123)
       end
 
       it 'returns empty values when the request to the API failed' do
-        @search.stub(:get).and_raise(StandardError)
-        @search.fetch_facet_values('category').should eq('All' => 0)
+        allow(@search).to receive(:get).and_raise(StandardError)
+
+        expect(@search.fetch_facet_values('category')).to eq('All' => 0)
       end
 
       it 'should add the All count to the hash with the sum of all facets' do
-        @search.fetch_facet_values('category')['All'].should eq 223
+        expect(@search.fetch_facet_values('category')['All']).to eq 223
       end
 
       it 'doesnt return the All count ' do
-        @search.fetch_facet_values('category', all: false).should_not have_key('All')
+        expect(@search.fetch_facet_values('category', all: false)).not_to have_key('All')
       end
 
       it 'memoizes the facet_values' do
-        @search.should_receive(:get).once
+        expect(@search).to receive(:get).once
+
         @search.fetch_facet_values('category')
         @search.fetch_facet_values('category')
       end
@@ -655,21 +674,24 @@ module Supplejack
       context 'sorting' do
         before(:each) do
           @facet = Supplejack::Facet.new('category', 'All' => 223, 'Books' => 123, 'Images' => 100)
-          Supplejack::Facet.stub(:new) { @facet }
+          allow(Supplejack::Facet).to receive(:new) { @facet }
         end
 
         it 'initializes a Supplejack::Facet' do
-          Supplejack::Facet.should_receive(:new).with('category', 'All' => 223, 'Books' => 123, 'Images' => 100)
+          expect(Supplejack::Facet).to receive(:new).with('category', 'All' => 223, 'Books' => 123, 'Images' => 100)
+
           @search.fetch_facet_values('category')
         end
 
         it 'tells the facet how to sort the values' do
-          @facet.should_receive(:values).with(:index)
+          expect(@facet).to receive(:values).with(:index)
+
           @search.fetch_facet_values('category', sort: :index)
         end
 
         it 'doesn\'t sort by default' do
-          @facet.should_receive(:values).with(nil)
+          expect(@facet).to receive(:values).with(nil)
+
           @search.fetch_facet_values('category')
         end
       end
@@ -681,100 +703,110 @@ module Supplejack
       end
 
       it 'removes type filter from the search request' do
-        @search.facet_values_params('type').should include(and: { year: 2001 })
+        expect(@search.facet_values_params('type')).to include(and: { year: 2001 })
       end
 
       it 'requests 0 results per_page' do
-        @search.facet_values_params('type').should include(per_page: 0)
+        expect(@search.facet_values_params('type')).to include(per_page: 0)
       end
 
       it 'adds without filters' do
         @search = Search.new(i: { :type => 'Person', :year => 2001, '-group' => 'Group' }, text: 'Dogs')
-        @search.facet_values_params('type').should include(without: { group: 'Group' })
+
+        expect(@search.facet_values_params('type')).to include(without: { group: 'Group' })
       end
 
       it 'only adds the and_filters to :and' do
         @search = Search.new(i: { :type => 'Person', :year => 2001, '-group' => 'Group' }, text: 'Dogs')
-        @search.facet_values_params('type').should include(and: { year: 2001 })
+
+        expect(@search.facet_values_params('type')).to include(and: { year: 2001 })
       end
 
       it 'gets the facet_values for a record_type 1' do
         @search = Search.new(i: { type: 'Person' }, h: { group: 'Group' }, text: 'Dogs', record_type: 1)
-        @search.facet_values_params('group').should include(and: {})
+
+        expect(@search.facet_values_params('group')).to include(and: {})
       end
 
       it 'restricts results to filters specified in without accessor' do
         @search = Search.new
         @search.without = { website: 'Flickr' }
-        @search.facet_values_params('type').should include(without: { website: 'Flickr' })
+
+        expect(@search.facet_values_params('type')).to include(without: { website: 'Flickr' })
       end
 
       it 'merges in the filters specified in without' do
         @search = Search.new(i: { '-type' => 'Person' })
         @search.without = { website: 'Flickr' }
-        @search.facet_values_params('type').should include(without: { website: 'Flickr', type: 'Person' })
+
+        expect(@search.facet_values_params('type')).to include(without: { website: 'Flickr', type: 'Person' })
       end
 
       it 'adds the restrictions set in the and variable' do
         @search = Search.new
         @search.and = { content_partner: 'NLNZ' }
-        @search.facet_values_params('type').should include(and: { content_partner: 'NLNZ' })
+
+        expect(@search.facet_values_params('type')).to include(and: { content_partner: 'NLNZ' })
       end
 
       it 'adds the restrictions set in the or variable' do
         @search = Search.new
         @search.or = { content_partner: 'NLNZ' }
-        @search.facet_values_params('type').should include(or: { content_partner: 'NLNZ' })
+
+        expect(@search.facet_values_params('type')).to include(or: { content_partner: 'NLNZ' })
       end
 
       it 'memoizes the params' do
         @search = Search.new
-        @search.should_receive(:url_format).once.and_return(double(:url_format, and_filters: {}))
+        expect(@search).to receive(:url_format).once.and_return(double(:url_format, and_filters: {}))
+
         @search.facet_values_params('type')
         @search.facet_values_params('type')
       end
 
       it 'adds a parameter for facets_per_page if the option is present' do
-        @search.facet_values_params('type', facets_per_page: 15).should include(facets_per_page: 15)
+        expect(@search.facet_values_params('type', facets_per_page: 15)).to include(facets_per_page: 15)
       end
     end
 
     describe '#facet_values' do
-      before(:each) do
+      before do
         @search = Search.new
-        @search.stub(:fetch_facet_values) { { 'Books' => 100 } }
+        allow(@search).to receive(:fetch_facet_values) { { 'Books' => 100 } }
       end
 
       context 'caching disabled' do
-        before(:each) do
-          Supplejack.stub(:enable_caching) { false }
+        before do
+          allow(Supplejack).to receive(:enable_caching) { false }
         end
 
         it 'fetches the facet values' do
-          @search.should_receive(:fetch_facet_values).with('category', anything)
+          expect(@search).to receive(:fetch_facet_values).with('category', anything)
+
           @search.facet_values('category', anything)
         end
       end
     end
 
     describe '#merge_extra_filters' do
-      before(:each) do
-        @search = Search.new
-      end
+      before { @search = Search.new }
 
       it 'merges the and filters' do
         @search.and = { type: 'Person' }
-        @search.merge_extra_filters(and: { location: 'Wellington' }).should eq(and: { location: 'Wellington', type: 'Person' })
+
+        expect(@search.merge_extra_filters(and: { location: 'Wellington' })).to eq(and: { location: 'Wellington', type: 'Person' })
       end
 
       it 'merges the or filters' do
         @search.or = { type: 'Person' }
-        @search.merge_extra_filters(and: { location: 'Wellington' }).should eq(and: { location: 'Wellington' }, or: { type: 'Person' })
+
+        expect(@search.merge_extra_filters(and: { location: 'Wellington' })).to eq(and: { location: 'Wellington' }, or: { type: 'Person' })
       end
 
       it 'merges the without filters' do
         @search.without = { type: 'Person' }
-        @search.merge_extra_filters(and: { location: 'Wellington' }).should eq(and: { location: 'Wellington' }, without: { type: 'Person' })
+
+        expect(@search.merge_extra_filters(and: { location: 'Wellington' })).to eq(and: { location: 'Wellington' }, without: { type: 'Person' })
       end
     end
   end

--- a/spec/supplejack/story_item_relation_spec.rb
+++ b/spec/supplejack/story_item_relation_spec.rb
@@ -27,7 +27,7 @@ module Supplejack
       end
 
       it 'returns an empty array of items when the user_set attributes records are nil' do
-        expect(supplejack_story).to receive(:attributes).and_return(nil)
+        allow(supplejack_story).to receive(:attributes).and_return(nil)
 
         expect(relation.all).to be_empty
       end
@@ -84,32 +84,29 @@ module Supplejack
     end
 
     describe '#create' do
-      let(:item) { double(:item).as_null_object }
+      let(:item) { instance_double(Supplejack::StoryItem).as_null_object }
 
       it 'builds and saves the item' do
-        expect(relation).to receive(:build) { item }
+        allow(relation).to receive(:build).and_return(item)
         expect(item).to receive(:save)
 
         relation.create
       end
 
       it 'passes the parameters along to the build method' do
-        expect(relation).to receive(:build).with(type: 'embed') { item }
+        allow(relation).to receive(:build).with(type: 'embed').and_return(item)
 
         relation.create(type: 'embed')
       end
     end
 
-    context 'items array behaviour' do
+    context 'when items are arrays' do
       it 'executes array methods on the @items array' do
         expect(relation.any? { |x| x.id == 1 }).to eq(true)
       end
 
-      it 'should be able to iterate through the items relation' do
-        relation.each do |item|
-          expect(item).to be_a Supplejack::StoryItem
-        end
-
+      it 'iterates through the items relation' do
+        expect(relation).to all(be_a Supplejack::StoryItem)
         expect(relation.size).to eq(2)
       end
     end

--- a/spec/supplejack/story_item_spec.rb
+++ b/spec/supplejack/story_item_spec.rb
@@ -19,7 +19,7 @@ module Supplejack
 
       Supplejack::StoryItem::ATTRIBUTES.each do |attribute|
         it "should initialize the attribute #{attribute}" do
-          Supplejack::StoryItem.new(attribute => 'value').send(attribute).should eq 'value'
+          expect(Supplejack::StoryItem.new(attribute => 'value').send(attribute)).to eq 'value'
         end
       end
     end
@@ -45,7 +45,7 @@ module Supplejack
       end
 
       context 'HTTP error is raised' do
-        before { item.stub(:post).and_raise(RestClient::Forbidden.new) }
+        before { allow(item).to receive(:post).and_raise(RestClient::Forbidden.new) }
 
         it 'returns false when an HTTP error is raised' do
           expect(item.save).to eq(false)
@@ -69,9 +69,7 @@ module Supplejack
       end
 
       context 'HTTP error is raised' do
-        before do
-          item.stub(:delete).and_raise(RestClient::Forbidden.new)
-        end
+        before { allow(item).to receive(:delete).and_raise(RestClient::Forbidden.new) }
 
         it 'returns false when a HTTP error is raised' do
           expect(item.destroy).to eq(false)

--- a/spec/supplejack/story_item_spec.rb
+++ b/spec/supplejack/story_item_spec.rb
@@ -6,28 +6,28 @@ module Supplejack
   describe StoryItem do
     describe '#initialize' do
       it 'accepts a hash of attributes' do
-        Supplejack::StoryItem.new(type: 'embed', sub_type: 'supplejack_user')
+        described_class.new(type: 'embed', sub_type: 'supplejack_user')
       end
 
       it 'accepts a hash with string keys' do
-        expect(Supplejack::StoryItem.new('type' => 'embed', 'sub_type' => 'supplejack_user').type).to eq('embed')
+        expect(described_class.new('type' => 'embed', 'sub_type' => 'supplejack_user').type).to eq('embed')
       end
 
       it 'handles nil attributes' do
-        expect(Supplejack::StoryItem.new(nil).type).to be_nil
+        expect(described_class.new(nil).type).to be_nil
       end
 
       Supplejack::StoryItem::ATTRIBUTES.each do |attribute|
-        it "should initialize the attribute #{attribute}" do
-          expect(Supplejack::StoryItem.new(attribute => 'value').send(attribute)).to eq 'value'
+        it "initializes the attribute #{attribute}" do
+          expect(described_class.new(attribute => 'value').send(attribute)).to eq 'value'
         end
       end
     end
 
     describe '#save' do
-      let(:item) { Supplejack::StoryItem.new(type: 'embed', sub_type: 'supplejack_user', story_id: '1234', api_key: 'abc') }
+      let(:item) { described_class.new(type: 'embed', sub_type: 'supplejack_user', story_id: '1234', api_key: 'abc') }
 
-      context 'new item' do
+      context 'when item is new ' do
         it 'triggers a POST request to create a story_item with the story api_key' do
           expect(item).to receive(:post).with('/stories/1234/items', { user_key: 'abc' }, item: { meta: {}, type: 'embed', sub_type: 'supplejack_user' })
 
@@ -35,7 +35,7 @@ module Supplejack
         end
       end
 
-      context 'existing item' do
+      context 'with existing item' do
         it 'triggers a PATCH request to update a story_item with the story api_key' do
           item.id = 1
           expect(item).to receive(:patch).with('/stories/1234/items/1', { user_key: 'abc' }, item: { meta: {}, type: 'embed', sub_type: 'supplejack_user' })
@@ -44,7 +44,7 @@ module Supplejack
         end
       end
 
-      context 'HTTP error is raised' do
+      context 'when HTTP error is raised' do
         before { allow(item).to receive(:post).and_raise(RestClient::Forbidden.new) }
 
         it 'returns false when an HTTP error is raised' do
@@ -60,7 +60,7 @@ module Supplejack
     end
 
     describe '#destroy' do
-      let(:item) { Supplejack::StoryItem.new(story_id: '1234', api_key: 'abc', id: 5) }
+      let(:item) { described_class.new(story_id: '1234', api_key: 'abc', id: 5) }
 
       it 'triggers a DELETE request with the story api_key' do
         expect(item).to receive(:delete).with('/stories/1234/items/5', user_key: 'abc')
@@ -68,7 +68,7 @@ module Supplejack
         item.destroy
       end
 
-      context 'HTTP error is raised' do
+      context 'when HTTP error is raised' do
         before { allow(item).to receive(:delete).and_raise(RestClient::Forbidden.new) }
 
         it 'returns false when a HTTP error is raised' do
@@ -84,7 +84,7 @@ module Supplejack
     end
 
     describe '#update_attributes' do
-      let(:story_item) { Supplejack::StoryItem.new(type: 'foo', sub_type: 'bar') }
+      let(:story_item) { described_class.new(type: 'foo', sub_type: 'bar') }
 
       it 'sets the attributes on the StoryItem' do
         story_item.update_attributes(type: 'Mac')

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -8,21 +8,21 @@ end
 
 module Supplejack
   describe Story do
-    before { allow(Supplejack).to receive(:enable_caching) { false } }
+    before { allow(Supplejack).to receive(:enable_caching).and_return(false) }
 
     describe '#initialize' do
       Supplejack::Story::ATTRIBUTES.reject { |a| a =~ /_at/ }.each do |attribute|
         it "initializes the #{attribute}" do
-          expect(Supplejack::Story.new(attribute => 'value').send(attribute)).to eq 'value'
+          expect(described_class.new(attribute => 'value').send(attribute)).to eq 'value'
         end
       end
 
       it 'handles nil attributes' do
-        expect { Supplejack::Story.new(nil).attributes }.not_to raise_error
+        expect { described_class.new(nil).attributes }.not_to raise_error
       end
 
       it 'initializes a user object' do
-        story = Supplejack::Story.new(user: { name: 'Juanito' })
+        story = described_class.new(user: { name: 'Juanito' })
         expect(story.user).to be_a Supplejack::User
         expect(story.user.name).to eq 'Juanito'
       end
@@ -30,7 +30,7 @@ module Supplejack
 
     %i[updated_at created_at].each do |field|
       describe "##{field}" do
-        let(:story) { Supplejack::Story.new(field => '2012-08-17T10:01:00+12:00') }
+        let(:story) { described_class.new(field => '2012-08-17T10:01:00+12:00') }
 
         it 'converts it into a time object' do
           expect(story.send(field)).to be_a Time
@@ -53,7 +53,7 @@ module Supplejack
     end
 
     describe '#attributes' do
-      let(:story) { Supplejack::Story.new({ name: 'Dogs', description: 'Hi', special_field: true }) }
+      let(:story) { described_class.new({ name: 'Dogs', description: 'Hi', special_field: true }) }
 
       context 'when Supplejack special_story_attributes is not configured' do
         it 'returns a hash of the set attributes' do
@@ -68,6 +68,8 @@ module Supplejack
       context 'when Supplejack special_story_attributes is configured' do
         before { Supplejack.special_story_attributes = %i[special_field] }
 
+        after { Supplejack.special_story_attributes = %i[] }
+
         it 'returns a hash of the set attributes' do
           expect(story.attributes).to include(name: 'Dogs', description: 'Hi')
         end
@@ -75,14 +77,12 @@ module Supplejack
         it 'doesnt return special_field' do
           expect(story.attributes).to include(special_field: true)
         end
-
-        after { Supplejack.special_story_attributes = %i[] }
       end
     end
 
     describe '#api_attributes' do
       it 'only returns the fields that can be modified' do
-        story = Supplejack::Story.new(name: 'foo', id: 'bar')
+        story = described_class.new(name: 'foo', id: 'bar')
 
         attributes = story.api_attributes
 
@@ -93,64 +93,64 @@ module Supplejack
 
     describe '#tag_list' do
       it 'returns a comma sepparated list of tags' do
-        expect(Supplejack::Story.new(tags: %w[dog cat]).tag_list).to eq 'dog, cat'
+        expect(described_class.new(tags: %w[dog cat]).tag_list).to eq 'dog, cat'
       end
     end
 
     describe '#private?' do
       it 'returns true when the privacy is private' do
-        expect(Supplejack::Story.new(privacy: 'private').private?).to eq true
+        expect(described_class.new(privacy: 'private').private?).to eq true
       end
 
       it 'returns false when the privacy is something else' do
-        expect(Supplejack::Story.new(privacy: 'public').private?).to eq false
+        expect(described_class.new(privacy: 'public').private?).to eq false
       end
     end
 
     describe '#public?' do
       it 'returns false when the privacy is private' do
-        expect(Supplejack::Story.new(privacy: 'private').public?).to eq false
+        expect(described_class.new(privacy: 'private').public?).to eq false
       end
 
       it 'returns true when the privacy is public' do
-        expect(Supplejack::Story.new(privacy: 'public').public?).to eq true
+        expect(described_class.new(privacy: 'public').public?).to eq true
       end
     end
 
     describe '#hidden?' do
       it 'returns false when the privacy is not hidden' do
-        expect(Supplejack::Story.new(privacy: 'public').hidden?).to eq false
+        expect(described_class.new(privacy: 'public').hidden?).to eq false
       end
 
       it 'returns true when the privacy is hidden' do
-        expect(Supplejack::Story.new(privacy: 'hidden').hidden?).to eq true
+        expect(described_class.new(privacy: 'hidden').hidden?).to eq true
       end
     end
 
     describe '#new_record?' do
       it "returns true when the user_set doesn't have a id" do
-        expect(Supplejack::Story.new.new_record?).to eq true
+        expect(described_class.new.new_record?).to eq true
       end
 
       it 'returns false when the user_set has a id' do
-        expect(Supplejack::Story.new(id: '1234abc').new_record?).to eq false
+        expect(described_class.new(id: '1234abc').new_record?).to eq false
       end
     end
 
     describe '#api_key' do
       it 'returns the users api_key' do
-        expect(Supplejack::Story.new(user: { api_key: 'foobar' }).api_key).to eq 'foobar'
+        expect(described_class.new(user: { api_key: 'foobar' }).api_key).to eq 'foobar'
       end
     end
 
     describe '#save' do
-      context 'Story is a new_record' do
+      context 'when story is a new_record' do
         let(:attributes) { { name: 'Story Name', description: nil, errors: nil, privacy: nil, copyright: nil, featured_at: nil, featured: nil, approved: nil, tags: nil, subjects: nil, record_ids: nil, count: nil, category: nil } }
         let(:user) { { api_key: 'foobar' } }
-        let(:story) { Supplejack::Story.new(attributes.merge(user: user)) }
+        let(:story) { described_class.new(attributes.merge(user: user)) }
 
         before do
-          expect(Supplejack::Story).to receive(:post).with('/stories', { user_key: 'foobar' }, story: attributes) do
+          allow(described_class).to receive(:post).with('/stories', { user_key: 'foobar' }, story: attributes) do
             {
               'id' => 'new-id',
               'name' => attributes[:name],
@@ -181,20 +181,20 @@ module Supplejack
         end
 
         it 'returns false for anything other that a 200 response' do
-          RSpec::Mocks.space.proxy_for(Supplejack::Story).reset
-          allow(Supplejack::Story).to receive(:post).and_raise(RestClient::Forbidden.new)
+          RSpec::Mocks.space.proxy_for(described_class).reset
+          allow(described_class).to receive(:post).and_raise(RestClient::Forbidden.new)
 
           expect(story.save).to eq false
         end
       end
 
-      context 'story is not new' do
+      context 'when story is not new' do
         let(:attributes) { { name: 'Story Name', description: 'desc', errors: nil, privacy: nil, copyright: nil, featured_at: nil, featured: nil, approved: nil, tags: nil, subjects: nil, record_ids: nil, count: nil, category: nil } }
         let(:user) { { api_key: 'foobar' } }
-        let(:story) { Supplejack::Story.new(attributes.merge(user: user, id: '123')) }
+        let(:story) { described_class.new(attributes.merge(user: user, id: '123')) }
 
         before do
-          expect(Supplejack::Story).to receive(:patch).with('/stories/123', { user_key: user[:api_key] }, story: attributes) do
+          allow(described_class).to receive(:patch).with('/stories/123', { user_key: user[:api_key] }, story: attributes) do
             {
               'id' => 'new-id',
               'name' => attributes[:name],
@@ -208,10 +208,6 @@ module Supplejack
           end
         end
 
-        it 'triggers a PATCH request to /stories/123.json with the user set user_key' do
-          story.save
-        end
-
         it 'updates the attributes with the response' do
           story.save
 
@@ -220,10 +216,10 @@ module Supplejack
       end
 
       context 'when request fails' do
-        let(:story) { Supplejack::Story.new({ name: 'Story Name', user: { api_key: 'foobar' }, id: '123' }) }
+        let(:story) { described_class.new({ name: 'Story Name', user: { api_key: 'foobar' }, id: '123' }) }
 
         it 'triggers a POST request to reposition_items' do
-          allow(Supplejack::Story).to receive(:patch).and_return({ 'errors' => 'save failed' })
+          allow(described_class).to receive(:patch).and_return({ 'errors' => 'save failed' })
 
           expect(story.save).to be false
           expect(story.errors).to eq 'save failed'
@@ -233,12 +229,12 @@ module Supplejack
 
     describe '#reposition_items' do
       let(:user) { { api_key: 'foobar' } }
-      let(:story) { Supplejack::Story.new({ name: 'Story Name', description: 'desc', user: user, id: '123' }) }
+      let(:story) { described_class.new({ name: 'Story Name', description: 'desc', user: user, id: '123' }) }
       let(:reposition_attributes) { [{ id: '111', position: 1 }, { id: '112', position: 2 }] }
 
       context 'when request is successful' do
         it 'triggers a POST request to reposition_items' do
-          expect(Supplejack::Story).to receive(:post).with('/stories/123/reposition_items', { user_key: user[:api_key] }, items: reposition_attributes)
+          expect(described_class).to receive(:post).with('/stories/123/reposition_items', { user_key: user[:api_key] }, items: reposition_attributes)
 
           story.reposition_items(reposition_attributes)
         end
@@ -246,7 +242,7 @@ module Supplejack
 
       context 'when request fails' do
         it 'triggers a POST request to reposition_items' do
-          allow(Supplejack::Story).to receive(:post).and_return({ 'errors' => 'repositioning failed' })
+          allow(described_class).to receive(:post).and_return({ 'errors' => 'repositioning failed' })
 
           expect(story.reposition_items(reposition_attributes)).to be false
           expect(story.errors).to eq 'repositioning failed'
@@ -255,7 +251,7 @@ module Supplejack
     end
 
     describe '#update_attributes' do
-      let(:story) { Supplejack::Story.new(name: 'test', description: 'test') }
+      let(:story) { described_class.new(name: 'test', description: 'test') }
 
       it 'sets the attributes on the Story' do
         story.update_attributes(name: 'Mac')
@@ -271,7 +267,7 @@ module Supplejack
     end
 
     describe '#attributes=' do
-      let(:story) { Supplejack::Story.new(name: 'Foo') }
+      let(:story) { described_class.new(name: 'Foo') }
 
       it 'updates the attributes on the story' do
         story.attributes = { name: 'Mac' }
@@ -279,7 +275,7 @@ module Supplejack
         expect(story.name).to eq 'Mac'
       end
 
-      it 'should only update passed attributes' do
+      it 'updates only passed attributes' do
         story.id = '12345'
         story.attributes = { name: 'Mac' }
 
@@ -288,34 +284,34 @@ module Supplejack
     end
 
     describe '#destroy' do
-      let(:story) { Supplejack::Story.new(id: '999', user: { api_key: 'keysome' }) }
+      let(:story) { described_class.new(id: '999', user: { api_key: 'keysome' }) }
 
       it 'executes a delete request to the API with the user set api_key' do
-        expect(Supplejack::Story).to receive(:delete).with('/stories/999', user_key: 'keysome')
+        expect(described_class).to receive(:delete).with('/stories/999', user_key: 'keysome')
 
         expect(story.destroy).to eq(true)
       end
 
       it 'returns false when the response is not a 200' do
-        expect(Supplejack::Story).to receive(:delete).and_raise(RestClient::Forbidden.new)
+        allow(described_class).to receive(:delete).and_raise(RestClient::Forbidden.new)
 
         expect(story.destroy).to eq(false)
         expect(story.errors).to eq 'Forbidden'
       end
 
       it 'returns false when it is a new user set' do
-        expect(story).to receive(:new_record?) { true }
-        expect(Supplejack::Story).not_to receive(:delete)
+        allow(story).to receive(:new_record?).and_return(true)
 
+        expect(described_class).not_to receive(:delete)
         expect(story.destroy).to eq(false)
       end
     end
 
     describe '#reload' do
-      let(:story) { Supplejack::Story.new(id: '123456') }
+      let(:story) { described_class.new(id: '123456') }
 
       it 'fetches the set from the api and repopulates the set' do
-        expect(Supplejack::Story).to receive(:get).with('/stories/123456') { { 'id' => 'abc' } }
+        allow(described_class).to receive(:get).with('/stories/123456').and_return({ 'id' => 'abc' })
 
         story.reload
 
@@ -323,13 +319,13 @@ module Supplejack
       end
 
       it 'raises Supplejack::StoryNotFound if the Story is not found' do
-        expect(Supplejack::Story).to receive(:get).and_raise(RestClient::ResourceNotFound.new)
+        allow(described_class).to receive(:get).and_raise(RestClient::ResourceNotFound.new)
 
         expect { story.reload }.to raise_error(Supplejack::StoryNotFound)
       end
 
       it 'removes the existing @items relation' do
-        expect(Supplejack::Story).to receive(:get).with('/stories/123456') { { 'id' => 'abc' } }
+        allow(described_class).to receive(:get).with('/stories/123456').and_return({ 'id' => 'abc' })
 
         story.items
         story.reload
@@ -343,19 +339,19 @@ module Supplejack
       let(:user) { { api_key: api_key } }
 
       it 'returns true when the Story is public' do
-        story = Supplejack::Story.new(privacy: 'public')
+        story = described_class.new(privacy: 'public')
 
         expect(story.viewable_by?(nil)).to eq(true)
       end
 
       it 'returns true when the user_set is hidden' do
-        story = Supplejack::Story.new(privacy: 'hidden')
+        story = described_class.new(privacy: 'hidden')
 
         expect(story.viewable_by?(nil)).to eq(true)
       end
 
-      context 'private set' do
-        let(:story) { Supplejack::Story.new(privacy: 'private', user: user) }
+      context 'when set is private' do
+        let(:story) { described_class.new(privacy: 'private', user: user) }
 
         it 'returns false when the user is not present' do
           expect(story.viewable_by?(nil)).to eq(false)
@@ -367,7 +363,7 @@ module Supplejack
 
         it 'returns false if both the api_key in the user and the set are nil' do
           user = { api_key: nil }
-          story = Supplejack::Story.new(privacy: 'private', user: user)
+          story = described_class.new(privacy: 'private', user: user)
 
           expect(story.viewable_by?(Supplejack::User.new(user))).to eq(false)
         end
@@ -377,9 +373,9 @@ module Supplejack
     describe '#owned_by?' do
       let(:api_key) { '123456' }
       let(:user) { Supplejack::User.new(api_key: api_key) }
-      let(:users_story) { Supplejack::Story.new(user: { api_key: api_key }) }
-      let(:other_story) { Supplejack::Story.new(user: { api_key: '123' }) }
-      let(:nil_api_key_story) { Supplejack::Story.new(user: { api_key: nil }) }
+      let(:users_story) { described_class.new(user: { api_key: api_key }) }
+      let(:other_story) { described_class.new(user: { api_key: '123' }) }
+      let(:nil_api_key_story) { described_class.new(user: { api_key: nil }) }
 
       it "returns true when the users api_key is the same as the set's" do
         expect(users_story.owned_by?(user)).to eq(true)
@@ -396,29 +392,26 @@ module Supplejack
 
     describe '#all_public_stories' do
       let(:api_key) { '123456' }
+
       it 'returns an array with all stories from /stories/moderations endpoint' do
-        expect(Supplejack::Story).to receive(:get).and_return(
+        allow(described_class).to receive(:get).and_return(
           'sets' => [
             Supplejack::User.new(api_key: api_key).attributes,
             Supplejack::User.new(api_key: api_key).attributes
           ]
         )
 
-        expect(Supplejack::Story.all_public_stories.count).to eq(2)
+        expect(described_class.all_public_stories.count).to eq(2)
       end
 
       it 'includes stories metadata if :meta_included option passed' do
-        expect(Supplejack::Story).to receive(:get).and_return(
-          'sets' => [
-            Supplejack::User.new(api_key: api_key).attributes,
-            Supplejack::User.new(api_key: api_key).attributes
-          ],
-          'per_page' => 10,
-          'page' => 1,
-          'total' => 2,
-          'total_filtered' => 2
+        allow(described_class).to receive(:get).and_return(
+          'sets' => [Supplejack::User.new(api_key: api_key).attributes, Supplejack::User.new(api_key: api_key).attributes],
+          'per_page' => 10, 'page' => 1,
+          'total' => 2, 'total_filtered' => 2
         )
-        expect(Supplejack::Story.all_public_stories(meta_included: true)).to include('sets', 'total_filtered', 'total', 'page', 'per_page')
+
+        expect(described_class.all_public_stories(meta_included: true)).to include('sets', 'total_filtered', 'total', 'page', 'per_page')
       end
     end
 
@@ -451,15 +444,15 @@ module Supplejack
       end
 
       it 'fetches the Story from the API' do
-        expect(Supplejack::Story).to receive(:get).with('/stories/123abc', {}).and_return(attributes)
+        allow(described_class).to receive(:get).with('/stories/123abc', {}).and_return(attributes)
 
-        Supplejack::Story.find('123abc')
+        described_class.find('123abc')
       end
 
       it 'initializes a Story object' do
-        expect(Supplejack::Story).to receive(:get).with('/stories/123abc', {}).and_return(attributes)
+        allow(described_class).to receive(:get).with('/stories/123abc', {}).and_return(attributes)
 
-        story = Supplejack::Story.find('123abc')
+        story = described_class.find('123abc')
 
         expect(story.attributes).to eq(attributes.symbolize_keys)
       end
@@ -467,31 +460,31 @@ module Supplejack
       # I've removed this functionality because I don't understand the use case
       # If we _do_ end up needing it in the future we can re add it
       it 'initializes the Story and sets the user api_key' do
-        expect(Supplejack::Story).to receive(:get).with('/stories/123abc', user_key: '98765').and_return(attributes)
+        allow(described_class).to receive(:get).with('/stories/123abc', user_key: '98765').and_return(attributes)
 
-        story = Supplejack::Story.find('123abc', user_key: '98765')
+        story = described_class.find('123abc', user_key: '98765')
 
         expect(story.api_key).to eq('98765')
       end
 
       it 'raises a Supplejack::StoryNotFound' do
-        allow(Supplejack::Story).to receive(:get).and_raise(RestClient::ResourceNotFound)
+        allow(described_class).to receive(:get).and_raise(RestClient::ResourceNotFound)
 
-        expect { Supplejack::Story.find(id: '123') }.to raise_error(Supplejack::StoryNotFound)
+        expect { described_class.find(id: '123') }.to raise_error(Supplejack::StoryNotFound)
       end
     end
 
     describe '#featured' do
       it 'fetches stories from the api' do
-        expect(Supplejack::Story).to receive(:get).with('/stories/featured')
-        Supplejack::Story.featured
+        expect(described_class).to receive(:get).with('/stories/featured')
+        described_class.featured
       end
 
       context 'when RestClient service unavailable' do
-        before { allow(Supplejack::Story).to receive(:get).and_raise(RestClient::ServiceUnavailable) }
+        before { allow(described_class).to receive(:get).and_raise(RestClient::ServiceUnavailable) }
 
         it 'fetches stories from the api' do
-          expect { Supplejack::Story.featured }.to raise_error(Supplejack::ApiNotAvailable)
+          expect { described_class.featured }.to raise_error(Supplejack::ApiNotAvailable)
         end
       end
     end

--- a/spec/supplejack/story_spec.rb
+++ b/spec/supplejack/story_spec.rb
@@ -8,7 +8,7 @@ end
 
 module Supplejack
   describe Story do
-    before { Supplejack.stub(:enable_caching) { false } }
+    before { allow(Supplejack).to receive(:enable_caching) { false } }
 
     describe '#initialize' do
       Supplejack::Story::ATTRIBUTES.reject { |a| a =~ /_at/ }.each do |attribute|
@@ -182,7 +182,7 @@ module Supplejack
 
         it 'returns false for anything other that a 200 response' do
           RSpec::Mocks.space.proxy_for(Supplejack::Story).reset
-          Supplejack::Story.stub(:post).and_raise(RestClient::Forbidden.new)
+          allow(Supplejack::Story).to receive(:post).and_raise(RestClient::Forbidden.new)
 
           expect(story.save).to eq false
         end
@@ -451,13 +451,13 @@ module Supplejack
       end
 
       it 'fetches the Story from the API' do
-        Supplejack::Story.should_receive(:get).with('/stories/123abc', {}).and_return(attributes)
+        expect(Supplejack::Story).to receive(:get).with('/stories/123abc', {}).and_return(attributes)
 
         Supplejack::Story.find('123abc')
       end
 
       it 'initializes a Story object' do
-        Supplejack::Story.should_receive(:get).with('/stories/123abc', {}).and_return(attributes)
+        expect(Supplejack::Story).to receive(:get).with('/stories/123abc', {}).and_return(attributes)
 
         story = Supplejack::Story.find('123abc')
 
@@ -475,7 +475,7 @@ module Supplejack
       end
 
       it 'raises a Supplejack::StoryNotFound' do
-        Supplejack::Story.stub(:get).and_raise(RestClient::ResourceNotFound)
+        allow(Supplejack::Story).to receive(:get).and_raise(RestClient::ResourceNotFound)
 
         expect { Supplejack::Story.find(id: '123') }.to raise_error(Supplejack::StoryNotFound)
       end
@@ -483,7 +483,7 @@ module Supplejack
 
     describe '#featured' do
       it 'fetches stories from the api' do
-        Supplejack::Story.should_receive(:get).with('/stories/featured')
+        expect(Supplejack::Story).to receive(:get).with('/stories/featured')
         Supplejack::Story.featured
       end
 

--- a/spec/supplejack/url_formats/item_hash_spec.rb
+++ b/spec/supplejack/url_formats/item_hash_spec.rb
@@ -35,7 +35,7 @@ module Supplejack
         end
 
         it 'returns the per_page set in the initializer' do
-          allow(Supplejack).to receive(:per_page) { 15 }
+          allow(Supplejack).to receive(:per_page).and_return(15)
 
           expect(item_hash.to_api_hash).to include(per_page: 15)
         end
@@ -73,7 +73,7 @@ module Supplejack
         end
 
         it 'returns the default set of fields from config' do
-          allow(Supplejack).to receive(:fields) { %i[default atl] }
+          allow(Supplejack).to receive(:fields).and_return(%i[default atl])
 
           expect(item_hash.to_api_hash).to include(fields: 'default,atl')
         end
@@ -90,7 +90,7 @@ module Supplejack
           expect(item_hash(solr_query: 'dc_type:Images').to_api_hash).to include(solr_query: 'dc_type:Images')
         end
 
-        it 'shouldn\'t send the solr_query if empty' do
+        it 'sends no solr_query if empty' do
           expect(item_hash(solr_query: '').to_api_hash).not_to have_key(:solr_query)
         end
       end
@@ -100,7 +100,7 @@ module Supplejack
           expect(item_hash(i: { 'sample_filter' => 'Groups' }).and_filters).to eq(sample_filter: 'Groups')
         end
 
-        it 'returns every filter' do
+        it 'skips restricted filter' do
           expect(item_hash(i: { 'sample_filter' => 'Groups', '-content_partner' => 'nlnz' }).and_filters).to eq(sample_filter: 'Groups')
         end
 
@@ -188,7 +188,7 @@ module Supplejack
       end
 
       describe '#filters' do
-        context 'default records' do
+        context 'with default records' do
           it 'returns the hash within the :i key and symbolizes them' do
             expect(item_hash(i: { 'location' => 'NZ' }).filters).to eq(location: 'NZ')
           end
@@ -218,7 +218,7 @@ module Supplejack
           end
         end
 
-        context 'headings tab' do
+        context 'with headings tab' do
           it 'returns the hash within the :h key' do
             expect(item_hash(h: { 'heading_type' => 'Name' }, record_type: '1').filters).to eq(heading_type: 'Name')
           end
@@ -241,7 +241,7 @@ module Supplejack
           end
         end
 
-        context 'filter_type is provided' do
+        context 'when filter_type is provided' do
           it 'returns "i" when filter_type is :items' do
             expect(item_hash(record_type: 1).filter_symbol(:items)).to eq 'i'
           end
@@ -301,13 +301,15 @@ module Supplejack
           expect(item_hash({ i: { name: 'John' } }, search).options(plus: { i: { name: 'James' } })[:i]).to include(name: %w[John James])
         end
 
-        it 'only removes one value from the same facet' do
+        it 'removes one value from the same 2 facet' do
           search = Supplejack::Search.new(i: { name: %w[John James] })
+
           expect(item_hash({ i: { name: %w[John James] } }, search).options(except: [{ name: 'James' }])[:i]).to include(name: 'John')
         end
 
-        it 'only removes one value from the same facet' do
+        it 'removes one value from the same 3 facet' do
           search = Supplejack::Search.new(i: { name: %w[John James Jake] })
+
           expect(item_hash({ i: { name: %w[John James Jake] } }, search).options(except: [{ name: 'James' }])[:i]).to include(name: %w[John Jake])
         end
 
@@ -317,7 +319,7 @@ module Supplejack
           expect(item_hash(params, search).options(except: [{ name: %w[James John] }])[:i]).not_to have_key(:name)
         end
 
-        context 'in the items tab' do
+        context 'when in the items tab' do
           it 'merges filters in the :plus parameter to the unlocked hash' do
             expect(item_hash({}, search).options(plus: { i: { 'type' => 'Something' } })[:i]).to include(type: 'Something')
           end

--- a/spec/supplejack/url_formats/item_hash_spec.rb
+++ b/spec/supplejack/url_formats/item_hash_spec.rb
@@ -11,224 +11,221 @@ module Supplejack
     describe ItemHash do
       describe '#to_api_hash' do
         it 'doesn\'t return blank text' do
-          item_hash(text: '').to_api_hash.should_not have_key(:text)
+          expect(item_hash(text: '').to_api_hash).not_to have_key(:text)
         end
 
         it 'returns the text in the params' do
-          item_hash(text: 'dog').to_api_hash.should include(text: 'dog')
+          expect(item_hash(text: 'dog').to_api_hash).to include(text: 'dog')
         end
 
         it 'returns the geo_bbox in the params' do
-          item_hash(geo_bbox: '1,2,3,4').to_api_hash.should include(geo_bbox: '1,2,3,4')
+          expect(item_hash(geo_bbox: '1,2,3,4').to_api_hash).to include(geo_bbox: '1,2,3,4')
         end
 
         it 'type casts the record_type' do
-          item_hash(record_type: '1').to_api_hash.should include(record_type: 1)
+          expect(item_hash(record_type: '1').to_api_hash).to include(record_type: 1)
         end
 
         it 'returns by default page 1' do
-          item_hash.to_api_hash.should include(page: 1)
+          expect(item_hash.to_api_hash).to include(page: 1)
         end
 
         it 'returns the page parameter' do
-          item_hash(page: '3').to_api_hash.should include(page: 3)
+          expect(item_hash(page: '3').to_api_hash).to include(page: 3)
         end
 
         it 'returns the per_page set in the initializer' do
-          Supplejack.stub(:per_page) { 15 }
-          item_hash.to_api_hash.should include(per_page: 15)
+          allow(Supplejack).to receive(:per_page) { 15 }
+
+          expect(item_hash.to_api_hash).to include(per_page: 15)
         end
 
         it 'returns the per_page in the parameters' do
-          item_hash(per_page: '22').to_api_hash.should include(per_page: 22)
+          expect(item_hash(per_page: '22').to_api_hash).to include(per_page: 22)
         end
 
         it 'returns the and_filters in the :and key' do
-          item_hash(i: { description: 'Weird one' }).to_api_hash.should include(and: { description: 'Weird one' })
+          expect(item_hash(i: { description: 'Weird one' }).to_api_hash).to include(and: { description: 'Weird one' })
         end
 
         it 'returns the without_filters in the :without key' do
-          item_hash(i: { '-description' => 'Weird one' }).to_api_hash.should include(without: { description: 'Weird one' })
+          expect(item_hash(i: { '-description' => 'Weird one' }).to_api_hash).to include(without: { description: 'Weird one' })
         end
 
         it 'returns the facets' do
-          item_hash(facets: 'description,creator').to_api_hash.should include(facets: 'description,creator')
+          expect(item_hash(facets: 'description,creator').to_api_hash).to include(facets: 'description,creator')
         end
 
         it 'returns the facets per page' do
-          item_hash(facets_per_page: '12').to_api_hash.should include(facets_per_page: 12)
+          expect(item_hash(facets_per_page: '12').to_api_hash).to include(facets_per_page: 12)
         end
 
         it 'returns the sort and direction' do
-          item_hash(sort: 'title', direction: 'desc').to_api_hash.should include(sort: 'title', direction: 'desc')
+          expect(item_hash(sort: 'title', direction: 'desc').to_api_hash).to include(sort: 'title', direction: 'desc')
         end
 
         it 'doesn\'t return either sort nor direction when sort not present' do
-          item_hash(direction: 'desc').to_api_hash.should_not include(direction: 'desc')
+          expect(item_hash(direction: 'desc').to_api_hash).not_to include(direction: 'desc')
         end
 
         it 'returns default direction "asc"' do
-          item_hash(sort: 'title').to_api_hash.should include(direction: 'asc')
+          expect(item_hash(sort: 'title').to_api_hash).to include(direction: 'asc')
         end
 
         it 'returns the default set of fields from config' do
-          Supplejack.stub(:fields) { %i[default atl] }
-          item_hash.to_api_hash.should include(fields: 'default,atl')
+          allow(Supplejack).to receive(:fields) { %i[default atl] }
+
+          expect(item_hash.to_api_hash).to include(fields: 'default,atl')
         end
 
         it 'overrides the fields from the parameters' do
-          item_hash(fields: 'verbose,authorities').to_api_hash.should include(fields: 'verbose,authorities')
+          expect(item_hash(fields: 'verbose,authorities').to_api_hash).to include(fields: 'verbose,authorities')
         end
 
         it 'doesn\'t break when nil options hash' do
-          item_hash(nil).to_api_hash.should be_a Hash
+          expect(item_hash(nil).to_api_hash).to be_a Hash
         end
 
         it 'sends the solr_query option to the api' do
-          item_hash(solr_query: 'dc_type:Images').to_api_hash.should include(solr_query: 'dc_type:Images')
+          expect(item_hash(solr_query: 'dc_type:Images').to_api_hash).to include(solr_query: 'dc_type:Images')
         end
 
         it 'shouldn\'t send the solr_query if empty' do
-          item_hash(solr_query: '').to_api_hash.should_not have_key(:solr_query)
+          expect(item_hash(solr_query: '').to_api_hash).not_to have_key(:solr_query)
         end
-
-        # it 'adds query_fields to the hash if present' do
-        #   convert(@search, {:i => {:creator_text => 'john'}}).should include(:query_fields => [:creator])
-        # end
-        #
-        # it 'doesn't add empty query fields' do
-        #   convert(@search, {:i => {:display_collection => 'nzlnz'}}).should_not have_key(:query_fields)
-        # end
       end
 
       describe '#and_filters' do
         it 'returns every filter' do
-          item_hash(i: { 'sample_filter' => 'Groups' }).and_filters.should eq(sample_filter: 'Groups')
+          expect(item_hash(i: { 'sample_filter' => 'Groups' }).and_filters).to eq(sample_filter: 'Groups')
         end
 
         it 'returns every filter' do
-          item_hash(i: { 'sample_filter' => 'Groups', '-content_partner' => 'nlnz' }).and_filters.should eq(sample_filter: 'Groups')
+          expect(item_hash(i: { 'sample_filter' => 'Groups', '-content_partner' => 'nlnz' }).and_filters).to eq(sample_filter: 'Groups')
         end
 
         it 'removes any _text filters' do
-          item_hash(i: { 'filter_with_text' => 'dog' }).and_filters.should eq({})
+          expect(item_hash(i: { 'filter_with_text' => 'dog' }).and_filters).to eq({})
         end
 
         it 'returns only item filters if filter_type is :items' do
-          item_hash(i: { 'subject' => 'dog' }, h: { 'heading_type' => 'record_type' }, record_type: 1).and_filters(:items).should eq(subject: 'dog')
+          expect(item_hash(i: { 'subject' => 'dog' }, h: { 'heading_type' => 'record_type' }, record_type: 1).and_filters(:items)).to eq(subject: 'dog')
         end
 
         it 'returns only headings filters if filter_type is :headings' do
-          item_hash(i: { 'subject' => 'dog' }, h: { 'heading_type' => 'record_type' }, record_type: 0).and_filters(:headings).should eq(heading_type: 'record_type')
+          expect(item_hash(i: { 'subject' => 'dog' }, h: { 'heading_type' => 'record_type' }, record_type: 0).and_filters(:headings)).to eq(heading_type: 'record_type')
         end
 
         it 'memoizes :i and :h filters seperatly' do
           hash = item_hash(i: { 'subject' => 'dog' }, h: { 'heading_type' => 'record_type' })
-          hash.and_filters(:items).should eq(subject: 'dog')
-          hash.and_filters(:headings).should eq(heading_type: 'record_type')
+
+          expect(hash.and_filters(:items)).to eq(subject: 'dog')
+          expect(hash.and_filters(:headings)).to eq(heading_type: 'record_type')
         end
       end
 
       describe '#text_field?' do
         it 'returns true when the passed field is text' do
-          item_hash.text_field?('title_text').should be_truthy
+          expect(item_hash.text_field?('title_text')).to be true
         end
 
         it 'returns false when the passed field is not text' do
-          item_hash.text_field?('title_authority').should be_falsey
+          expect(item_hash.text_field?('title_authority')).to be false
         end
 
         it 'returns false when the passed field is nil' do
-          item_hash.text_field?(nil).should be_falsey
+          expect(item_hash.text_field?(nil)).to be false
         end
       end
 
       describe '#without_filters' do
         it 'returns only negative filters' do
-          item_hash(i: { '-negative_category' => 'Groups', 'positive_category' => 'nlnz' }).without_filters.should eq(negative_category: 'Groups')
+          expect(item_hash(i: { '-negative_category' => 'Groups', 'positive_category' => 'nlnz' }).without_filters).to eq(negative_category: 'Groups')
         end
 
         it 'returns only item filters if filter_type is :items' do
-          item_hash(i: { '-subject' => 'dog' }, h: { '-heading_type' => 'record_type' }, record_type: 1).without_filters(:items).should eq(subject: 'dog')
+          expect(item_hash(i: { '-subject' => 'dog' }, h: { '-heading_type' => 'record_type' }, record_type: 1).without_filters(:items)).to eq(subject: 'dog')
         end
 
         it 'returns only headings filters if filter_type is :headings' do
-          item_hash(i: { '-subject' => 'dog' }, h: { '-heading_type' => 'record_type' }, record_type: 0).without_filters(:headings).should eq(heading_type: 'record_type')
+          expect(item_hash(i: { '-subject' => 'dog' }, h: { '-heading_type' => 'record_type' }, record_type: 0).without_filters(:headings)).to eq(heading_type: 'record_type')
         end
 
         it 'memoizes :i and :h filters seperatly' do
           hash = item_hash(i: { '-subject' => 'dog' }, h: { '-heading_type' => 'record_type' })
-          hash.without_filters(:items).should eq(subject: 'dog')
-          hash.without_filters(:headings).should eq(heading_type: 'record_type')
+
+          expect(hash.without_filters(:items)).to eq(subject: 'dog')
+          expect(hash.without_filters(:headings)).to eq(heading_type: 'record_type')
         end
       end
 
       describe '#text' do
         it 'returns the text if present' do
-          item_hash.text('dog').should eq 'dog'
+          expect(item_hash.text('dog')).to eq 'dog'
         end
 
         it 'returns nil when text is not present' do
-          item_hash.text('').should be_nil
+          expect(item_hash.text('')).to be_nil
         end
 
         it 'extracts the text from name_text' do
-          item_hash(i: { name_text: 'john' }).text.should eq 'john'
+          expect(item_hash(i: { name_text: 'john' }).text).to eq 'john'
         end
       end
 
       describe '#query_fields' do
         it 'returns all fields that end with _text' do
-          item_hash(i: { name_text: 'john', location_text: 'New Zealand' }).query_fields.should include(:name, :location)
+          expect(item_hash(i: { name_text: 'john', location_text: 'New Zealand' }).query_fields).to include(:name, :location)
         end
 
         it 'returns nil when no filters match _text' do
-          item_hash(i: { sample_collection: 'nlnz' }).query_fields.should be_nil
+          expect(item_hash(i: { sample_collection: 'nlnz' }).query_fields).to be_nil
         end
 
         it 'returns only _text filters' do
-          item_hash(i: { name_text: 'john', sample_collection: 'nlnz' }).query_fields.should eq [:name]
+          expect(item_hash(i: { name_text: 'john', sample_collection: 'nlnz' }).query_fields).to eq [:name]
         end
       end
 
       describe '#filters' do
         context 'default records' do
           it 'returns the hash within the :i key and symbolizes them' do
-            item_hash(i: { 'location' => 'NZ' }).filters.should eq(location: 'NZ')
+            expect(item_hash(i: { 'location' => 'NZ' }).filters).to eq(location: 'NZ')
           end
 
           it 'merges in the locked filters' do
             result = { location: 'NZ', category: 'Images' }
-            item_hash(i: { 'location' => 'NZ' }, il: { 'category' => 'Images' }).filters.should eq(result)
+            expect(item_hash(i: { 'location' => 'NZ' }, il: { 'category' => 'Images' }).filters).to eq(result)
           end
 
           it 'returns :h filters with record_type parameter' do
-            item_hash(i: { 'location' => 'NZ' }, h: { dc_type: 'Names' }).filters(:headings).should eq(dc_type: 'Names')
+            expect(item_hash(i: { 'location' => 'NZ' }, h: { dc_type: 'Names' }).filters(:headings)).to eq(dc_type: 'Names')
           end
 
           it 'memoizes the :i and :h filters separately' do
             @hash = item_hash(i: { 'location' => 'NZ' }, h: { dc_type: 'Names' })
-            @hash.filters.should eq(location: 'NZ')
-            @hash.filters(:headings).should eq(dc_type: 'Names')
+
+            expect(@hash.filters).to eq(location: 'NZ')
+            expect(@hash.filters(:headings)).to eq(dc_type: 'Names')
           end
 
           it 'handles a string in the :i hash' do
-            item_hash(i: '').filters.should be_empty
+            expect(item_hash(i: '').filters.empty?).to be true
           end
 
           it 'handles a string in the :il hash' do
-            item_hash(il: '').filters.should be_empty
+            expect(item_hash(il: '').filters.empty?).to be true
           end
         end
 
         context 'headings tab' do
           it 'returns the hash within the :h key' do
-            item_hash(h: { 'heading_type' => 'Name' }, record_type: '1').filters.should eq(heading_type: 'Name')
+            expect(item_hash(h: { 'heading_type' => 'Name' }, record_type: '1').filters).to eq(heading_type: 'Name')
           end
 
           it 'merges in the locked filters' do
             result = { heading_type: 'Name', year: '1900' }
-            item_hash(h: { 'heading_type' => 'Name' }, hl: { 'year' => '1900' }, record_type: '1').filters.should eq(result)
+            expect(item_hash(h: { 'heading_type' => 'Name' }, hl: { 'year' => '1900' }, record_type: '1').filters).to eq(result)
           end
         end
       end
@@ -236,28 +233,28 @@ module Supplejack
       describe '#filter_symbol' do
         context 'when filter_type is nil' do
           it 'returns "i" when record_type is 0' do
-            item_hash(record_type: 0).filter_symbol.should eq 'i'
+            expect(item_hash(record_type: 0).filter_symbol).to eq 'i'
           end
 
           it 'returns "h" when record_type is 1' do
-            item_hash(record_type: 1).filter_symbol.should eq 'h'
+            expect(item_hash(record_type: 1).filter_symbol).to eq 'h'
           end
         end
 
         context 'filter_type is provided' do
           it 'returns "i" when filter_type is :items' do
-            item_hash(record_type: 1).filter_symbol(:items).should eq 'i'
+            expect(item_hash(record_type: 1).filter_symbol(:items)).to eq 'i'
           end
 
           it 'returns "h" when filter_type is :headings' do
-            item_hash(record_type: 0).filter_symbol(:headings).should eq 'h'
+            expect(item_hash(record_type: 0).filter_symbol(:headings)).to eq 'h'
           end
         end
       end
 
       describe '#filters_of_type' do
         it 'returns item unlocked filters' do
-          item_hash(i: { category: 'Images' }).filters_of_type(:i).should eq(category: 'Images')
+          expect(item_hash(i: { category: 'Images' }).filters_of_type(:i)).to eq(category: 'Images')
         end
       end
 
@@ -268,63 +265,63 @@ module Supplejack
 
         it 'returns a hash with the search parameters' do
           params = { i: { name: 'John' }, il: { type: 'Person' }, h: { heading_type: 'Name' }, hl: { year: '1900' } }
-          item_hash(params, @search).options.should eq params
+          expect(item_hash(params, @search).options).to eq params
         end
 
         it 'doesnt return any empty values' do
-          item_hash({ i: { name: '', type: nil, location: 'Wellington' } }, @search).options.should eq(i: { location: 'Wellington' })
+          expect(item_hash({ i: { name: '', type: nil, location: 'Wellington' } }, @search).options).to eq(i: { location: 'Wellington' })
         end
 
         it 'returns a empty hash when filters are empty' do
-          item_hash({ i: { name: '', type: nil } }, @search).options.should eq({})
+          expect(item_hash({ i: { name: '', type: nil } }, @search).options).to eq({})
         end
 
         it 'doesn\'t return page parameter when page 1' do
-          item_hash({ page: 1 }, @search).options.should eq({})
+          expect(item_hash({ page: 1 }, @search).options).to eq({})
         end
 
         it 'doesn\'t return page parameter is empty' do
-          item_hash({}, @search).options.should eq({})
+          expect(item_hash({}, @search).options).to eq({})
         end
 
         it 'removes the filters in the :except parameter' do
-          item_hash({ i: { name: 'John' }, il: { type: 'Person' } }, @search).options(except: [:name]).should eq(il: { type: 'Person' })
+          expect(item_hash({ i: { name: 'John' }, il: { type: 'Person' } }, @search).options(except: [:name])).to eq(il: { type: 'Person' })
         end
 
         it 'includes the record_type when is 1' do
           search = Supplejack::Search.new(record_type: 1)
-          item_hash({ record_type: 1 }, search).options.should include(record_type: 1)
+          expect(item_hash({ record_type: 1 }, search).options).to include(record_type: 1)
         end
 
         it 'excludes the page parameter' do
           search = Supplejack::Search.new(page: 3)
-          item_hash({}, search).options(except: [:page]).should_not include(page: 3)
+          expect(item_hash({}, search).options(except: [:page])).not_to include(page: 3)
         end
 
         it 'adds multiple values to the same facet' do
           search = Supplejack::Search.new(i: { name: 'John' })
-          item_hash({ i: { name: 'John' } }, search).options(plus: { i: { name: 'James' } })[:i].should include(name: %w[John James])
+          expect(item_hash({ i: { name: 'John' } }, search).options(plus: { i: { name: 'James' } })[:i]).to include(name: %w[John James])
         end
 
         it 'only removes one value from the same facet' do
           search = Supplejack::Search.new(i: { name: %w[John James] })
-          item_hash({ i: { name: %w[John James] } }, search).options(except: [{ name: 'James' }])[:i].should include(name: 'John')
+          expect(item_hash({ i: { name: %w[John James] } }, search).options(except: [{ name: 'James' }])[:i]).to include(name: 'John')
         end
 
         it 'only removes one value from the same facet' do
           search = Supplejack::Search.new(i: { name: %w[John James Jake] })
-          item_hash({ i: { name: %w[John James Jake] } }, search).options(except: [{ name: 'James' }])[:i].should include(name: %w[John Jake])
+          expect(item_hash({ i: { name: %w[John James Jake] } }, search).options(except: [{ name: 'James' }])[:i]).to include(name: %w[John Jake])
         end
 
         it 'removes the whole facet if there is no remaining values' do
           params = { i: { name: %w[John James], type: 'Person' } }
           search = Supplejack::Search.new(params)
-          item_hash(params, search).options(except: [{ name: %w[James John] }])[:i].should_not have_key(:name)
+          expect(item_hash(params, search).options(except: [{ name: %w[James John] }])[:i]).not_to have_key(:name)
         end
 
         context 'in the items tab' do
           it 'merges filters in the :plus parameter to the unlocked hash' do
-            item_hash({}, @search).options(plus: { i: { 'type' => 'Something' } })[:i].should include(type: 'Something')
+            expect(item_hash({}, @search).options(plus: { i: { 'type' => 'Something' } })[:i]).to include(type: 'Something')
           end
         end
       end

--- a/spec/supplejack/url_formats/item_hash_spec.rb
+++ b/spec/supplejack/url_formats/item_hash_spec.rb
@@ -203,10 +203,10 @@ module Supplejack
           end
 
           it 'memoizes the :i and :h filters separately' do
-            @hash = item_hash(i: { 'location' => 'NZ' }, h: { dc_type: 'Names' })
+            test_hash = item_hash(i: { 'location' => 'NZ' }, h: { dc_type: 'Names' })
 
-            expect(@hash.filters).to eq(location: 'NZ')
-            expect(@hash.filters(:headings)).to eq(dc_type: 'Names')
+            expect(test_hash.filters).to eq(location: 'NZ')
+            expect(test_hash.filters(:headings)).to eq(dc_type: 'Names')
           end
 
           it 'handles a string in the :i hash' do
@@ -259,33 +259,31 @@ module Supplejack
       end
 
       describe '#options' do
-        before(:each) do
-          @search = Supplejack::Search.new
-        end
+        let(:search) { Supplejack::Search.new }
 
         it 'returns a hash with the search parameters' do
           params = { i: { name: 'John' }, il: { type: 'Person' }, h: { heading_type: 'Name' }, hl: { year: '1900' } }
-          expect(item_hash(params, @search).options).to eq params
+          expect(item_hash(params, search).options).to eq params
         end
 
         it 'doesnt return any empty values' do
-          expect(item_hash({ i: { name: '', type: nil, location: 'Wellington' } }, @search).options).to eq(i: { location: 'Wellington' })
+          expect(item_hash({ i: { name: '', type: nil, location: 'Wellington' } }, search).options).to eq(i: { location: 'Wellington' })
         end
 
         it 'returns a empty hash when filters are empty' do
-          expect(item_hash({ i: { name: '', type: nil } }, @search).options).to eq({})
+          expect(item_hash({ i: { name: '', type: nil } }, search).options).to eq({})
         end
 
         it 'doesn\'t return page parameter when page 1' do
-          expect(item_hash({ page: 1 }, @search).options).to eq({})
+          expect(item_hash({ page: 1 }, search).options).to eq({})
         end
 
         it 'doesn\'t return page parameter is empty' do
-          expect(item_hash({}, @search).options).to eq({})
+          expect(item_hash({}, search).options).to eq({})
         end
 
         it 'removes the filters in the :except parameter' do
-          expect(item_hash({ i: { name: 'John' }, il: { type: 'Person' } }, @search).options(except: [:name])).to eq(il: { type: 'Person' })
+          expect(item_hash({ i: { name: 'John' }, il: { type: 'Person' } }, search).options(except: [:name])).to eq(il: { type: 'Person' })
         end
 
         it 'includes the record_type when is 1' do
@@ -321,7 +319,7 @@ module Supplejack
 
         context 'in the items tab' do
           it 'merges filters in the :plus parameter to the unlocked hash' do
-            expect(item_hash({}, @search).options(plus: { i: { 'type' => 'Something' } })[:i]).to include(type: 'Something')
+            expect(item_hash({}, search).options(plus: { i: { 'type' => 'Something' } })[:i]).to include(type: 'Something')
           end
         end
       end

--- a/spec/supplejack/user_set_relation_spec.rb
+++ b/spec/supplejack/user_set_relation_spec.rb
@@ -7,14 +7,13 @@ module Supplejack
     let(:user) { Supplejack::User.new(authentication_token: '123abc') }
     let(:relation) { Supplejack::UserSetRelation.new(user) }
 
-    before :each do
+    before do
       allow(relation).to receive(:get) { { 'sets' => [{ 'id' => '1', 'name' => 'dogs', 'count' => 1, 'priority' => 2 }, { 'id' => '2', 'name' => 'Favourites', 'count' => 1, 'priority' => 1 }] } }
     end
 
     describe '#initialize' do
       it 'initializes with a UserSet object' do
-        @user = user
-        expect(Supplejack::UserSetRelation.new(@user).user).to eq @user
+        expect(Supplejack::UserSetRelation.new(user).user).to eq user
       end
     end
 
@@ -106,7 +105,7 @@ module Supplejack
     end
 
     describe '#order' do
-      before :each do
+      before do
         allow(relation).to receive(:get) { { 'sets' => [{ 'name' => 'dogs', 'priority' => 2, 'count' => 3 }, { 'name' => 'zavourites', 'priority' => 1, 'count' => 2 }, { 'name' => 'Favourites', 'priority' => 2, 'count' => 1 }] } }
       end
 

--- a/spec/supplejack/user_set_relation_spec.rb
+++ b/spec/supplejack/user_set_relation_spec.rb
@@ -5,15 +5,15 @@ require 'spec_helper'
 module Supplejack
   describe UserSetRelation do
     let(:user) { Supplejack::User.new(authentication_token: '123abc') }
-    let(:relation) { Supplejack::UserSetRelation.new(user) }
+    let(:relation) { described_class.new(user) }
 
     before do
-      allow(relation).to receive(:get) { { 'sets' => [{ 'id' => '1', 'name' => 'dogs', 'count' => 1, 'priority' => 2 }, { 'id' => '2', 'name' => 'Favourites', 'count' => 1, 'priority' => 1 }] } }
+      allow(relation).to receive(:get).and_return({ 'sets' => [{ 'id' => '1', 'name' => 'dogs', 'count' => 1, 'priority' => 2 }, { 'id' => '2', 'name' => 'Favourites', 'count' => 1, 'priority' => 1 }] })
     end
 
     describe '#initialize' do
       it 'initializes with a UserSet object' do
-        expect(Supplejack::UserSetRelation.new(user).user).to eq user
+        expect(described_class.new(user).user).to eq user
       end
     end
 
@@ -27,12 +27,10 @@ module Supplejack
       it 'returns a array of UserSet objects' do
         expect(relation.fetch_sets).to be_a Array
 
-        relation.fetch_sets.each do |set|
-          expect(set).to be_a Supplejack::UserSet
-        end
+        expect(relation).to all(be_a Supplejack::UserSet)
       end
 
-      it 'should order the user sets by priority' do
+      it 'orders the user sets by priority' do
         expect(relation.fetch_sets.first.name).to eq 'Favourites'
 
         expect(relation.fetch_sets.last.name).to eq 'dogs'
@@ -40,8 +38,8 @@ module Supplejack
     end
 
     describe 'sets_response' do
-      context 'caching disabled' do
-        before { allow(Supplejack).to receive(:enable_caching) { false } }
+      context 'when caching is disabled' do
+        before { allow(Supplejack).to receive(:enable_caching).and_return(false) }
 
         it 'fetches the user sets with the App api_key' do
           expect(relation).to receive(:get).with('/users/123abc/sets', {})
@@ -49,9 +47,9 @@ module Supplejack
           relation.sets_response
         end
 
-        context 'user with use_own_api_key set to true' do
+        context 'when user with use_own_api_key set to true' do
           it 'fetches the user sets with it\'s own API Key' do
-            allow(user).to receive(:use_own_api_key?) { true }
+            allow(user).to receive(:use_own_api_key?).and_return(true)
 
             expect(relation).to receive(:get).with('/sets', api_key: '123abc')
 
@@ -98,40 +96,33 @@ module Supplejack
       it 'initializes the UserSet and saves it' do
         user_set = relation.build(name: 'Dogs')
 
-        expect(relation).to receive(:build).with(name: 'Dogs') { user_set }
-        expect(user_set).to receive(:save) { true }
+        allow(relation).to receive(:build).with(name: 'Dogs').and_return(user_set)
+        allow(user_set).to receive(:save).and_return(true)
         expect(relation.create(name: 'Dogs')).to be_a Supplejack::UserSet
       end
     end
 
     describe '#order' do
       before do
-        allow(relation).to receive(:get) { { 'sets' => [{ 'name' => 'dogs', 'priority' => 2, 'count' => 3 }, { 'name' => 'zavourites', 'priority' => 1, 'count' => 2 }, { 'name' => 'Favourites', 'priority' => 2, 'count' => 1 }] } }
+        allow(relation).to receive(:get).and_return({ 'sets' => [{ 'name' => 'dogs', 'priority' => 2, 'count' => 3 }, { 'name' => 'zavourites', 'priority' => 1, 'count' => 2 }, { 'name' => 'Favourites', 'priority' => 2, 'count' => 1 }] })
       end
 
       it 'orders the sets based on the name' do
-        expect(relation.order(:name)[0].name).to eq 'zavourites'
-        expect(relation.order(:name)[1].name).to eq 'dogs'
-        expect(relation.order(:name)[2].name).to eq 'Favourites'
+        expect(relation.order(:name).map(&:name)).to eq %w[zavourites dogs Favourites]
       end
+
       it 'orders the sets based on the count' do
-        expect(relation.order(:count)[0].name).to eq 'zavourites'
-        expect(relation.order(:count)[1].name).to eq 'Favourites'
-        expect(relation.order(:count)[2].name).to eq 'dogs'
+        expect(relation.order(:count).map(&:name)).to eq %w[zavourites Favourites dogs]
       end
 
       it 'orders the sets based on the updated_at ignoring the priority' do
         allow(relation).to receive(:get) do
           { 'sets' => [
-            { 'name' => '1', 'updated_at' => Time.now.to_s, 'priority' => 2 },
-            { 'name' => '3', 'updated_at' => (Time.now - 4.hours).to_s, 'priority' => 1 },
-            { 'name' => '2', 'updated_at' => (Time.now - 1.hour).to_s, 'priority' => 2 }
+            { 'name' => 'dogs', 'updated_at' => Time.now.to_s, 'priority' => 2 },
+            { 'name' => 'zavourites', 'updated_at' => (Time.now - 4.hours).to_s, 'priority' => 1 }
           ] }
         end
-
-        expect(relation.order(:updated_at)[0].name).to eq '1'
-        expect(relation.order(:updated_at)[1].name).to eq '2'
-        expect(relation.order(:updated_at)[2].name).to eq '3'
+        expect(relation.order(:updated_at).map(&:name)).to eq %w[dogs zavourites]
       end
     end
 
@@ -141,20 +132,17 @@ module Supplejack
       end
     end
 
-    context 'user sets array behaviour' do
+    context 'when user sets is an array' do
       it 'executes array methods on the @sets array' do
-        allow(relation).to receive(:sets) { [] }
+        allow(relation).to receive(:sets).and_return([])
 
         expect(relation.size).to eq 0
       end
 
-      it 'should be able to iterate through the user sets relation' do
+      it 'iterates through the user sets relation' do
         allow(relation).to receive(:sets) { [Supplejack::UserSet.new] }
 
-        relation.each do |set|
-          expect(set).to be_a Supplejack::UserSet
-        end
-
+        expect(relation).to all(be_a Supplejack::UserSet)
         expect(relation.size).to eq 1
       end
     end

--- a/spec/supplejack/user_set_relation_spec.rb
+++ b/spec/supplejack/user_set_relation_spec.rb
@@ -8,50 +8,54 @@ module Supplejack
     let(:relation) { Supplejack::UserSetRelation.new(user) }
 
     before :each do
-      relation.stub(:get) { { 'sets' => [{ 'id' => '1', 'name' => 'dogs', 'count' => 1, 'priority' => 2 }, { 'id' => '2', 'name' => 'Favourites', 'count' => 1, 'priority' => 1 }] } }
+      allow(relation).to receive(:get) { { 'sets' => [{ 'id' => '1', 'name' => 'dogs', 'count' => 1, 'priority' => 2 }, { 'id' => '2', 'name' => 'Favourites', 'count' => 1, 'priority' => 1 }] } }
     end
 
     describe '#initialize' do
       it 'initializes with a UserSet object' do
         @user = user
-        Supplejack::UserSetRelation.new(@user).user.should eq @user
+        expect(Supplejack::UserSetRelation.new(@user).user).to eq @user
       end
     end
 
     describe '#fetch_sets' do
       it 'fetches the user sets with the App api_key' do
-        relation.should_receive(:get).with('/users/123abc/sets', {})
+        expect(relation).to receive(:get).with('/users/123abc/sets', {})
+
         relation.fetch_sets
       end
 
       it 'returns a array of UserSet objects' do
-        relation.fetch_sets.should be_a Array
+        expect(relation.fetch_sets).to be_a Array
+
         relation.fetch_sets.each do |set|
-          set.should be_a Supplejack::UserSet
+          expect(set).to be_a Supplejack::UserSet
         end
       end
 
       it 'should order the user sets by priority' do
-        relation.fetch_sets.first.name.should eq 'Favourites'
-        relation.fetch_sets.last.name.should eq 'dogs'
+        expect(relation.fetch_sets.first.name).to eq 'Favourites'
+
+        expect(relation.fetch_sets.last.name).to eq 'dogs'
       end
     end
 
     describe 'sets_response' do
       context 'caching disabled' do
-        before :each do
-          Supplejack.stub(:enable_caching) { false }
-        end
+        before { allow(Supplejack).to receive(:enable_caching) { false } }
 
         it 'fetches the user sets with the App api_key' do
-          relation.should_receive(:get).with('/users/123abc/sets', {})
+          expect(relation).to receive(:get).with('/users/123abc/sets', {})
+
           relation.sets_response
         end
 
         context 'user with use_own_api_key set to true' do
           it 'fetches the user sets with it\'s own API Key' do
-            user.stub(:use_own_api_key?) { true }
-            relation.should_receive(:get).with('/sets', api_key: '123abc')
+            allow(user).to receive(:use_own_api_key?) { true }
+
+            expect(relation).to receive(:get).with('/sets', api_key: '123abc')
+
             relation.sets_response
           end
         end
@@ -60,7 +64,8 @@ module Supplejack
 
     describe '#sets' do
       it 'memoizes the sets array' do
-        relation.should_receive(:fetch_sets).once { [] }
+        expect(relation).to receive(:fetch_sets).once.and_return([])
+
         relation.sets
         relation.sets
       end
@@ -68,7 +73,8 @@ module Supplejack
 
     describe '#find' do
       it 'finds a user and sets the correct api_key' do
-        Supplejack::UserSet.should_receive(:find).with('555', '123abc')
+        expect(Supplejack::UserSet).to receive(:find).with('555', '123abc')
+
         relation.find('555')
       end
     end
@@ -76,67 +82,81 @@ module Supplejack
     describe '#build' do
       it 'initializes a new UserSet with the user\'s api_key' do
         user_set = relation.build
-        user_set.should be_a UserSet
-        user_set.api_key.should eq '123abc'
+
+        expect(user_set).to be_a UserSet
+        expect(user_set.api_key).to eq '123abc'
       end
 
       it 'initializes the UserSet with the provided attributes' do
         user_set = relation.build(name: 'Dogs', description: 'Hi')
-        user_set.name.should eq 'Dogs'
-        user_set.description.should eq 'Hi'
+
+        expect(user_set.name).to eq 'Dogs'
+        expect(user_set.description).to eq 'Hi'
       end
     end
 
     describe '#create' do
       it 'initializes the UserSet and saves it' do
         user_set = relation.build(name: 'Dogs')
-        relation.should_receive(:build).with(name: 'Dogs') { user_set }
-        user_set.should_receive(:save) { true }
-        relation.create(name: 'Dogs').should be_a Supplejack::UserSet
+
+        expect(relation).to receive(:build).with(name: 'Dogs') { user_set }
+        expect(user_set).to receive(:save) { true }
+        expect(relation.create(name: 'Dogs')).to be_a Supplejack::UserSet
       end
     end
 
     describe '#order' do
       before :each do
-        relation.stub(:get) { { 'sets' => [{ 'name' => 'dogs', 'priority' => 2, 'count' => 3 }, { 'name' => 'zavourites', 'priority' => 1, 'count' => 2 }, { 'name' => 'Favourites', 'priority' => 2, 'count' => 1 }] } }
+        allow(relation).to receive(:get) { { 'sets' => [{ 'name' => 'dogs', 'priority' => 2, 'count' => 3 }, { 'name' => 'zavourites', 'priority' => 1, 'count' => 2 }, { 'name' => 'Favourites', 'priority' => 2, 'count' => 1 }] } }
       end
+
       it 'orders the sets based on the name' do
-        relation.order(:name)[0].name.should eq 'zavourites'
-        relation.order(:name)[1].name.should eq 'dogs'
-        relation.order(:name)[2].name.should eq 'Favourites'
+        expect(relation.order(:name)[0].name).to eq 'zavourites'
+        expect(relation.order(:name)[1].name).to eq 'dogs'
+        expect(relation.order(:name)[2].name).to eq 'Favourites'
       end
       it 'orders the sets based on the count' do
-        relation.order(:count)[0].name.should eq 'zavourites'
-        relation.order(:count)[1].name.should eq 'Favourites'
-        relation.order(:count)[2].name.should eq 'dogs'
+        expect(relation.order(:count)[0].name).to eq 'zavourites'
+        expect(relation.order(:count)[1].name).to eq 'Favourites'
+        expect(relation.order(:count)[2].name).to eq 'dogs'
       end
 
       it 'orders the sets based on the updated_at ignoring the priority' do
-        relation.stub(:get) { { 'sets' => [{ 'name' => '1', 'updated_at' => Time.now.to_s, 'priority' => 2 }, { 'name' => '3', 'updated_at' => (Time.now - 4.hours).to_s, 'priority' => 1 }, { 'name' => '2', 'updated_at' => (Time.now - 1.hour).to_s, 'priority' => 2 }] } }
-        relation.order(:updated_at)[0].name.should eq '1'
-        relation.order(:updated_at)[1].name.should eq '2'
-        relation.order(:updated_at)[2].name.should eq '3'
+        allow(relation).to receive(:get) do
+          { 'sets' => [
+            { 'name' => '1', 'updated_at' => Time.now.to_s, 'priority' => 2 },
+            { 'name' => '3', 'updated_at' => (Time.now - 4.hours).to_s, 'priority' => 1 },
+            { 'name' => '2', 'updated_at' => (Time.now - 1.hour).to_s, 'priority' => 2 }
+          ] }
+        end
+
+        expect(relation.order(:updated_at)[0].name).to eq '1'
+        expect(relation.order(:updated_at)[1].name).to eq '2'
+        expect(relation.order(:updated_at)[2].name).to eq '3'
       end
     end
 
     describe '#all' do
       it 'returns the actual array with the sets' do
-        relation.all.should be_a Array
+        expect(relation.all).to be_a Array
       end
     end
 
     context 'user sets array behaviour' do
       it 'executes array methods on the @sets array' do
-        relation.stub(:sets) { [] }
-        relation.size.should eq 0
+        allow(relation).to receive(:sets) { [] }
+
+        expect(relation.size).to eq 0
       end
 
       it 'should be able to iterate through the user sets relation' do
-        relation.stub(:sets) { [Supplejack::UserSet.new] }
+        allow(relation).to receive(:sets) { [Supplejack::UserSet.new] }
+
         relation.each do |set|
-          set.should be_a Supplejack::UserSet
+          expect(set).to be_a Supplejack::UserSet
         end
-        relation.size.should eq 1
+
+        expect(relation.size).to eq 1
       end
     end
   end

--- a/spec/supplejack/user_set_spec.rb
+++ b/spec/supplejack/user_set_spec.rb
@@ -10,7 +10,7 @@ module Supplejack
   describe UserSet do
     let(:supplejack_set) { Supplejack::UserSet.new(records: [{ record_id: 1, position: 2, title: 'Dogs' }]) }
 
-    before :each do
+    before do
       allow(Supplejack).to receive(:enable_caching) { false }
       allow(Supplejack::UserSet).to receive(:get) { { 'set' => { id: '123abc', name: 'Dogs', count: 0 } } }
     end
@@ -153,10 +153,9 @@ module Supplejack
     end
 
     describe '#save' do
-      before :each do
-        @attributes = { name: 'Dogs', description: 'hi', count: 3 }
-
-        allow(supplejack_set).to receive(:api_attributes) { @attributes }
+      let(:attributes) { { name: 'Dogs', description: 'hi', count: 3 } }
+      before do
+        allow(supplejack_set).to receive(:api_attributes) { attributes }
         allow(supplejack_set).to receive(:api_key) { '123abc' }
       end
 
@@ -164,7 +163,7 @@ module Supplejack
         before { allow(supplejack_set).to receive(:new_record?) { true } }
 
         it 'triggers a POST request to /sets.json' do
-          expect(Supplejack::UserSet).to receive(:post).with('/sets', { api_key: '123abc' }, set: @attributes) { { 'set' => { 'id' => 'new-id' } } }
+          expect(Supplejack::UserSet).to receive(:post).with('/sets', { api_key: '123abc' }, set: attributes) { { 'set' => { 'id' => 'new-id' } } }
 
           expect(supplejack_set.save).to be true
         end
@@ -185,14 +184,14 @@ module Supplejack
       end
 
       context 'user_set is not new' do
-        before :each do
+        before do
           allow(supplejack_set).to receive(:new_record?) { false }
 
           supplejack_set.id = '123'
         end
 
         it 'triggers a PUT request to /sets/123.json with the user set api_key' do
-          expect(Supplejack::UserSet).to receive(:put).with('/sets/123', { api_key: '123abc' }, set: @attributes)
+          expect(Supplejack::UserSet).to receive(:put).with('/sets/123', { api_key: '123abc' }, set: attributes)
 
           supplejack_set.save
         end
@@ -249,10 +248,10 @@ module Supplejack
         end
 
         it 'should accept a Time object too' do
-          @time = Time.now
-          supplejack_set.send("#{attr}=", @time)
+          time = Time.now
+          supplejack_set.send("#{attr}=", time)
 
-          expect(supplejack_set.send(attr)).to eq @time
+          expect(supplejack_set.send(attr)).to eq time
         end
       end
     end
@@ -294,7 +293,7 @@ module Supplejack
     end
 
     describe '#destroy' do
-      before :each do
+      before do
         allow(supplejack_set).to receive(:api_key) { '123abc' }
         allow(supplejack_set).to receive(:id) { '999' }
       end
@@ -323,7 +322,7 @@ module Supplejack
     describe '#reload' do
       let(:supplejack_set) { Supplejack::UserSet.new(id: '123456') }
 
-      before :each do
+      before do
         allow(Supplejack::UserSet).to receive(:get).with('/sets/123456') { { 'set' => { 'id' => 'abc' } } }
       end
 
@@ -402,21 +401,19 @@ module Supplejack
     end
 
     describe '#set_record_id?' do
-      before { @set = supplejack_set }
-
       it 'should return the record_id' do
-        allow(@set).to receive(:record).and_return('record_id' => 123)
+        allow(supplejack_set).to receive(:record).and_return('record_id' => 123)
 
-        expect(@set.set_record_id).to eq 123
+        expect(supplejack_set.set_record_id).to eq 123
       end
 
       it 'should return nil if the set doesn\'t have a record' do
-        expect(@set.set_record_id).to be nil
+        expect(supplejack_set.set_record_id).to be nil
       end
     end
 
     describe '#find' do
-      before :each do
+      before do
         @set = supplejack_set
         allow(Supplejack::UserSet).to receive(:new) { @set }
       end
@@ -449,7 +446,7 @@ module Supplejack
     end
 
     describe '#public_sets' do
-      before :each do
+      before do
         allow(Supplejack::UserSet).to receive(:get) { { 'sets' => [{ 'id' => '123', 'name' => 'Dog' }] } }
       end
 
@@ -460,8 +457,8 @@ module Supplejack
       end
 
       it 'returns an array of user set objects' do
-        @set = supplejack_set
-        expect(Supplejack::UserSet).to receive(:new).once.with('id' => '123', 'name' => 'Dog') { @set }
+        set = supplejack_set
+        expect(Supplejack::UserSet).to receive(:new).once.with('id' => '123', 'name' => 'Dog') { set }
 
         sets = Supplejack::UserSet.public_sets
 
@@ -477,7 +474,7 @@ module Supplejack
     end
 
     describe '#featured_sets' do
-      before :each do
+      before do
         allow(Supplejack::UserSet).to receive(:get) { { 'sets' => [{ 'id' => '123', 'name' => 'Dog' }] } }
       end
 
@@ -488,9 +485,9 @@ module Supplejack
       end
 
       it 'returns an array of user set objects' do
-        @set = supplejack_set
+        set = supplejack_set
 
-        expect(Supplejack::UserSet).to receive(:new).once.with('id' => '123', 'name' => 'Dog') { @set }
+        expect(Supplejack::UserSet).to receive(:new).once.with('id' => '123', 'name' => 'Dog') { set }
         sets = Supplejack::UserSet.featured_sets
 
         expect(sets).to be_a Array

--- a/spec/supplejack/user_set_spec.rb
+++ b/spec/supplejack/user_set_spec.rb
@@ -11,33 +11,30 @@ module Supplejack
     let(:supplejack_set) { Supplejack::UserSet.new(records: [{ record_id: 1, position: 2, title: 'Dogs' }]) }
 
     before :each do
-      Supplejack.stub(:enable_caching) { false }
-      Supplejack::UserSet.stub(:get) { { 'set' => { id: '123abc', name: 'Dogs', count: 0 } } }
+      allow(Supplejack).to receive(:enable_caching) { false }
+      allow(Supplejack::UserSet).to receive(:get) { { 'set' => { id: '123abc', name: 'Dogs', count: 0 } } }
     end
 
     describe '#initialize' do
       %i[id name description privacy url priority count tag_list featured approved].each do |attribute|
         it "initializes the #{attribute}" do
-          Supplejack::UserSet.new(attribute => 'value').send(attribute).should eq 'value'
+          expect(Supplejack::UserSet.new(attribute => 'value').send(attribute)).to eq 'value'
         end
       end
 
       it 'converts the updated_at into a time object' do
-        Supplejack::UserSet.new(updated_at: '2012-08-17T10:01:00+12:00').updated_at.should be_a Time
+        expect(Supplejack::UserSet.new(updated_at: '2012-08-17T10:01:00+12:00').updated_at).to be_a Time
       end
 
       it 'symbolizes the attributes hash' do
-        Supplejack::UserSet.new('name' => 'Dog').name.should eq 'Dog'
-      end
-
-      it 'handles nil attributes' do
-        Supplejack::UserSet.new(nil).attributes
+        expect(Supplejack::UserSet.new('name' => 'Dog').name).to eq 'Dog'
       end
 
       it 'initializes a user object' do
         user_set = Supplejack::UserSet.new(user: { name: 'Juanito' })
-        user_set.user.should be_a Supplejack::User
-        user_set.user.name.should eq 'Juanito'
+
+        expect(user_set.user).to be_a Supplejack::User
+        expect(user_set.user.name).to eq 'Juanito'
       end
     end
 
@@ -46,94 +43,100 @@ module Supplejack
         set = Supplejack::UserSet.new
         set.name = 'Dogs'
         set.description = 'Hi'
-        set.attributes.should include(name: 'Dogs', description: 'Hi')
+
+        expect(set.attributes).to include(name: 'Dogs', description: 'Hi')
       end
 
       it 'includes an array of :records' do
         set = Supplejack::UserSet.new
         set.records = [{ record_id: 1, position: 1 }]
-        set.attributes[:records].should eq [{ record_id: 1, position: 1 }]
+
+        expect(set.attributes[:records]).to eq [{ record_id: 1, position: 1 }]
       end
     end
 
     describe '#api_attributes' do
       it 'only returns the fields that can be stored' do
         supplejack_set.attributes = { count: 1, url: 'Hi' }
-        supplejack_set.should_not_receive(:count)
-        supplejack_set.should_not_receive(:url)
+
+        expect(supplejack_set).not_to receive(:count)
+        expect(supplejack_set).not_to receive(:url)
+
         supplejack_set.api_attributes
       end
 
       it 'should send the featured value' do
         supplejack_set.featured = true
-        supplejack_set.api_attributes.should include(featured: true)
+
+        expect(supplejack_set.api_attributes).to include(featured: true)
       end
 
       it 'returns a array of records with only id and position' do
-        supplejack_set.stub(:api_records) { [{ record_id: 1, position: 1 }] }
-        supplejack_set.api_attributes[:records].should eq [{ record_id: 1, position: 1 }]
+        allow(supplejack_set).to receive(:api_records) { [{ record_id: 1, position: 1 }] }
+
+        expect(supplejack_set.api_attributes[:records]).to eq [{ record_id: 1, position: 1 }]
       end
     end
 
     describe '#items' do
       it 'initializes a item_relation object' do
-        supplejack_set.items.should be_a Supplejack::ItemRelation
+        expect(supplejack_set.items).to be_a Supplejack::ItemRelation
       end
     end
 
     describe '#tag_list' do
       it 'returns a comma sepparated list of tags' do
-        Supplejack::UserSet.new(tags: %w[dog cat]).tag_list.should eq 'dog, cat'
+        expect(Supplejack::UserSet.new(tags: %w[dog cat]).tag_list).to eq 'dog, cat'
       end
     end
 
     describe '#priority' do
       it 'defaults to 1 when is null' do
-        Supplejack::UserSet.new.priority.should eq 1
+        expect(Supplejack::UserSet.new.priority).to eq 1
       end
 
       it 'keeps the value set' do
-        Supplejack::UserSet.new(priority: 0).priority.should eq 0
+        expect(Supplejack::UserSet.new(priority: 0).priority).to eq 0
       end
     end
 
     describe '#favourite?' do
       it 'returns true when the name is Favourites' do
-        Supplejack::UserSet.new(name: 'Favourites').favourite?.should be_truthy
+        expect(Supplejack::UserSet.new(name: 'Favourites').favourite?).to be true
       end
 
       it 'returns false when the name is something else' do
-        Supplejack::UserSet.new(name: 'Dogs').favourite?.should be_falsey
+        expect(Supplejack::UserSet.new(name: 'Dogs').favourite?).to be false
       end
     end
 
     describe '#private?' do
       it 'returns true when the privacy is private' do
-        Supplejack::UserSet.new(privacy: 'private').private?.should be_truthy
+        expect(Supplejack::UserSet.new(privacy: 'private').private?).to be true
       end
 
       it 'returns false when the privacy is something else' do
-        Supplejack::UserSet.new(privacy: 'public').private?.should be_falsey
+        expect(Supplejack::UserSet.new(privacy: 'public').private?).to be false
       end
     end
 
     describe '#public?' do
       it 'returns false when the privacy is private' do
-        Supplejack::UserSet.new(privacy: 'private').public?.should be_falsey
+        expect(Supplejack::UserSet.new(privacy: 'private').public?).to be false
       end
 
       it 'returns true when the privacy is public' do
-        Supplejack::UserSet.new(privacy: 'public').public?.should be_truthy
+        expect(Supplejack::UserSet.new(privacy: 'public').public?).to be true
       end
     end
 
     describe '#hidden?' do
       it 'returns false when the privacy is not hidden' do
-        Supplejack::UserSet.new(privacy: 'public').hidden?.should be_falsey
+        expect(Supplejack::UserSet.new(privacy: 'public').hidden?).to be false
       end
 
       it 'returns true when the privacy is hidden' do
-        Supplejack::UserSet.new(privacy: 'hidden').hidden?.should be_truthy
+        expect(Supplejack::UserSet.new(privacy: 'hidden').hidden?).to be true
       end
     end
 
@@ -141,51 +144,56 @@ module Supplejack
       let(:supplejack_set) { Supplejack::UserSet.new(records: [{ record_id: 1, position: 2, title: 'Dogs' }]) }
 
       it 'returns true when the record is part of the set' do
-        supplejack_set.record?(1).should be_truthy
+        expect(supplejack_set.record?(1)).to be true
       end
 
       it 'returns false when the record is not part of the set' do
-        supplejack_set.record?(3).should be_falsey
+        expect(supplejack_set.record?(3)).to be false
       end
     end
 
     describe '#save' do
       before :each do
         @attributes = { name: 'Dogs', description: 'hi', count: 3 }
-        supplejack_set.stub(:api_attributes) { @attributes }
-        supplejack_set.stub(:api_key) { '123abc' }
+
+        allow(supplejack_set).to receive(:api_attributes) { @attributes }
+        allow(supplejack_set).to receive(:api_key) { '123abc' }
       end
 
       context 'user_set is a new_record' do
-        before :each do
-          supplejack_set.stub(:new_record?) { true }
-        end
+        before { allow(supplejack_set).to receive(:new_record?) { true } }
 
         it 'triggers a POST request to /sets.json' do
-          Supplejack::UserSet.should_receive(:post).with('/sets', { api_key: '123abc' }, set: @attributes) { { 'set' => { 'id' => 'new-id' } } }
-          supplejack_set.save.should be_truthy
+          expect(Supplejack::UserSet).to receive(:post).with('/sets', { api_key: '123abc' }, set: @attributes) { { 'set' => { 'id' => 'new-id' } } }
+
+          expect(supplejack_set.save).to be true
         end
 
         it 'stores the id of the user_set' do
-          Supplejack::UserSet.stub(:post) { { 'set' => { 'id' => 'new-id' } } }
+          allow(Supplejack::UserSet).to receive(:post) { { 'set' => { 'id' => 'new-id' } } }
+
           supplejack_set.save
-          supplejack_set.id.should eq 'new-id'
+
+          expect(supplejack_set.id).to eq 'new-id'
         end
 
         it 'returns false for anything other that a 200 response' do
-          Supplejack::UserSet.stub(:post).and_raise(RestClient::Forbidden.new)
-          supplejack_set.save.should be_falsey
+          allow(Supplejack::UserSet).to receive(:post).and_raise(RestClient::Forbidden.new)
+
+          expect(supplejack_set.save).to be false
         end
       end
 
       context 'user_set is not new' do
         before :each do
-          supplejack_set.stub(:new_record?) { false }
+          allow(supplejack_set).to receive(:new_record?) { false }
+
           supplejack_set.id = '123'
         end
 
         it 'triggers a PUT request to /sets/123.json with the user set api_key' do
-          Supplejack::UserSet.should_receive(:put).with('/sets/123', { api_key: '123abc' }, set: @attributes)
+          expect(Supplejack::UserSet).to receive(:put).with('/sets/123', { api_key: '123abc' }, set: @attributes)
+
           supplejack_set.save
         end
       end
@@ -193,12 +201,14 @@ module Supplejack
 
     describe '#update_attributes' do
       it 'sets the attributes on the user_set' do
-        supplejack_set.should_receive('attributes=').with(name: 'Mac')
+        expect(supplejack_set).to receive('attributes=').with(name: 'Mac')
+
         supplejack_set.update_attributes(name: 'Mac')
       end
 
       it 'saves the user_set' do
-        supplejack_set.should_receive(:save)
+        expect(supplejack_set).to receive(:save)
+
         supplejack_set.update_attributes(name: 'Mac')
       end
     end
@@ -206,18 +216,21 @@ module Supplejack
     describe '#attributes=' do
       it 'updates the attributes on the user_set' do
         supplejack_set.attributes = { name: 'Mac' }
-        supplejack_set.name.should eq 'Mac'
+
+        expect(supplejack_set.name).to eq 'Mac'
       end
 
       it 'should only update passed attributes' do
         supplejack_set.id = '12345'
         supplejack_set.attributes = { name: 'Mac' }
-        supplejack_set.id.should eq '12345'
+
+        expect(supplejack_set.id).to eq '12345'
       end
 
       it 'replaces the records in the ordered form' do
         supplejack_set.attributes = { ordered_records: [9, 1, 5] }
-        supplejack_set.records.should eq([{ record_id: 9, position: 1 }, { record_id: 1, position: 2 }, { record_id: 5, position: 3 }])
+
+        expect(supplejack_set.records).to eq([{ record_id: 9, position: 1 }, { record_id: 1, position: 2 }, { record_id: 5, position: 3 }])
       end
     end
 
@@ -225,76 +238,85 @@ module Supplejack
       %i[created_at updated_at].each do |attr|
         it 'converts a string into a time object' do
           supplejack_set.send("#{attr}=", '2012-08-17T10:01:00+12:00')
-          supplejack_set.send(attr).should be_a Time
+
+          expect(supplejack_set.send(attr)).to be_a Time
         end
 
         it 'sets nil when the time is incorrect' do
           supplejack_set.send("#{attr}=", '838927587hdfhsjdf')
-          supplejack_set.send(attr).should be_nil
+
+          expect(supplejack_set.send(attr)).to be nil
         end
 
         it 'should accept a Time object too' do
           @time = Time.now
           supplejack_set.send("#{attr}=", @time)
-          supplejack_set.send(attr).should eq @time
+
+          expect(supplejack_set.send(attr)).to eq @time
         end
       end
     end
 
     describe '#api_records' do
       it 'generates a hash of records with position and record_id' do
-        supplejack_set.stub(:records) { [{ title: 'Hi', record_id: 1, position: 1 }] }
-        supplejack_set.api_records.should eq [{ record_id: 1, position: 1 }]
+        allow(supplejack_set).to receive(:records) { [{ title: 'Hi', record_id: 1, position: 1 }] }
+
+        expect(supplejack_set.api_records).to eq [{ record_id: 1, position: 1 }]
       end
 
       it 'removes records without a record_id' do
-        supplejack_set.stub(:records) { [{ title: 'Hi', record_id: 1, position: 1 }, { position: 6 }] }
-        supplejack_set.api_records.should eq [{ record_id: 1, position: 1 }]
+        allow(supplejack_set).to receive(:records) { [{ title: 'Hi', record_id: 1, position: 1 }, { position: 6 }] }
+
+        expect(supplejack_set.api_records).to eq [{ record_id: 1, position: 1 }]
       end
 
       it 'handles nil records' do
-        supplejack_set.stub(:records) { nil }
-        supplejack_set.api_records.should eq []
+        allow(supplejack_set).to receive(:records) { nil }
+
+        expect(supplejack_set.api_records).to eq []
       end
     end
 
     describe '#ordered_records_from_array' do
       it 'returns a hash with positons and record_ids' do
-        supplejack_set.ordered_records_from_array([9, 1, 5]).should eq([{ record_id: 9, position: 1 }, { record_id: 1, position: 2 }, { record_id: 5, position: 3 }])
+        expect(supplejack_set.ordered_records_from_array([9, 1, 5])).to eq([{ record_id: 9, position: 1 }, { record_id: 1, position: 2 }, { record_id: 5, position: 3 }])
       end
     end
 
     describe '#new_record?' do
       it 'returns true when the user_set doesn\'t have a id' do
-        Supplejack::UserSet.new.new_record?.should be_truthy
+        expect(Supplejack::UserSet.new.new_record?).to be true
       end
 
       it 'returns false when the user_set has a id' do
-        Supplejack::UserSet.new(id: '1234abc').new_record?.should be_falsey
+        expect(Supplejack::UserSet.new(id: '1234abc').new_record?).to be false
       end
     end
 
     describe '#destroy' do
       before :each do
-        supplejack_set.stub(:api_key) { '123abc' }
-        supplejack_set.stub(:id) { '999' }
+        allow(supplejack_set).to receive(:api_key) { '123abc' }
+        allow(supplejack_set).to receive(:id) { '999' }
       end
 
       it 'executes a delete request to the API with the user set api_key' do
-        Supplejack::UserSet.should_receive(:delete).with('/sets/999', api_key: '123abc')
-        supplejack_set.destroy.should be_truthy
+        expect(Supplejack::UserSet).to receive(:delete).with('/sets/999', api_key: '123abc')
+
+        expect(supplejack_set.destroy).to be true
       end
 
       it 'returns false when the response is not a 200' do
-        Supplejack::UserSet.stub(:delete).and_raise(RestClient::Forbidden.new)
-        supplejack_set.destroy.should be_falsey
-        supplejack_set.errors.should eq 'Forbidden'
+        allow(Supplejack::UserSet).to receive(:delete).and_raise(RestClient::Forbidden.new)
+
+        expect(supplejack_set.destroy).to be false
+        expect(supplejack_set.errors).to eq 'Forbidden'
       end
 
       it 'returns false when it is a new user set' do
-        supplejack_set.stub(:new_record?) { true }
-        Supplejack::UserSet.should_not_receive(:delete)
-        supplejack_set.destroy.should be_falsey
+        allow(supplejack_set).to receive(:new_record?) { true }
+
+        expect(Supplejack::UserSet).not_to receive(:delete)
+        expect(supplejack_set.destroy).to be false
       end
     end
 
@@ -302,51 +324,55 @@ module Supplejack
       let(:supplejack_set) { Supplejack::UserSet.new(id: '123456') }
 
       before :each do
-        Supplejack::UserSet.should_receive(:get).with('/sets/123456') { { 'set' => { 'id' => 'abc' } } }
+        allow(Supplejack::UserSet).to receive(:get).with('/sets/123456') { { 'set' => { 'id' => 'abc' } } }
       end
 
       it 'fetches the set from the api and repopulates the set' do
         supplejack_set.reload
-        supplejack_set.id.should eq 'abc'
+
+        expect(supplejack_set.id).to eq 'abc'
       end
 
       it 'removes the existing @items relation' do
         supplejack_set.items
         supplejack_set.reload
-        supplejack_set.instance_variable_get('@items').should be_nil
+
+        expect(supplejack_set.instance_variable_get('@items')).to be nil
       end
     end
 
     describe '#viewable_by?' do
       it 'returns true when the user_set is public' do
-        supplejack_set.stub(:public?) { true }
-        supplejack_set.viewable_by?(nil).should be_truthy
+        allow(supplejack_set).to receive(:public?) { true }
+
+        expect(supplejack_set.viewable_by?(nil)).to be true
       end
 
       it 'returns true when the user_set is hidden' do
-        supplejack_set.stub(:hidden?) { true }
-        supplejack_set.viewable_by?(nil).should be_truthy
+        allow(supplejack_set).to receive(:hidden?) { true }
+
+        expect(supplejack_set.viewable_by?(nil)).to be true
       end
 
       context 'private set' do
-        before :each do
-          supplejack_set.stub(:public?) { false }
-        end
+        before { allow(supplejack_set).to receive(:public?) { false } }
 
         it 'returns false when the user is not present' do
-          supplejack_set.viewable_by?(nil).should be_falsey
+          expect(supplejack_set.viewable_by?(nil)).to be false
         end
 
         it 'returns true when the user has the same api_key as the user_set' do
           user = double(:user, api_key: '12345')
           supplejack_set.api_key = '12345'
-          supplejack_set.viewable_by?(user).should be_truthy
+
+          expect(supplejack_set.viewable_by?(user)).to be true
         end
 
         it 'returns false if both the api_key in the user and the set are nil' do
           user = double(:user, api_key: nil)
           supplejack_set.api_key = nil
-          supplejack_set.viewable_by?(user).should be_falsey
+
+          expect(supplejack_set.viewable_by?(user)).to be false
         end
       end
     end
@@ -355,105 +381,120 @@ module Supplejack
       let(:user) { double(:user, api_key: '123456') }
 
       it 'returns true when the users api_key is the same as the set\'s' do
-        supplejack_set.stub(:api_key) { '123456' }
-        supplejack_set.owned_by?(user).should be_truthy
+        allow(supplejack_set).to receive(:api_key) { '123456' }
+
+        expect(supplejack_set.owned_by?(user)).to be true
       end
 
       it 'returns false when the set and user have different api_keys' do
-        supplejack_set.stub(:api_key) { '666' }
-        supplejack_set.owned_by?(user).should be_falsey
+        allow(supplejack_set).to receive(:api_key) { '666' }
+
+        expect(supplejack_set.owned_by?(user)).to be false
       end
 
       it 'returns false when both keys are nil' do
-        user.stub(:api_key) { nil }
-        supplejack_set.stub(:api_key) { nil }
-        supplejack_set.owned_by?(user).should be_falsey
+        allow(user).to receive(:api_key) { nil }
+
+        allow(supplejack_set).to receive(:api_key) { nil }
+
+        expect(supplejack_set.owned_by?(user)).to be false
       end
     end
 
     describe '#set_record_id?' do
-      before(:each) do
-        @set = supplejack_set
-      end
+      before { @set = supplejack_set }
 
       it 'should return the record_id' do
-        @set.stub(:record).and_return('record_id' => 123)
-        @set.set_record_id.should eq 123
+        allow(@set).to receive(:record).and_return('record_id' => 123)
+
+        expect(@set.set_record_id).to eq 123
       end
 
       it 'should return nil if the set doesn\'t have a record' do
-        @set.set_record_id.should be_nil
+        expect(@set.set_record_id).to be nil
       end
     end
 
     describe '#find' do
       before :each do
         @set = supplejack_set
-        Supplejack::UserSet.stub(:new) { @set }
+        allow(Supplejack::UserSet).to receive(:new) { @set }
       end
 
       it 'fetches the set from the api' do
-        Supplejack::UserSet.should_receive(:get).with('/sets/123abc', {})
+        expect(Supplejack::UserSet).to receive(:get).with('/sets/123abc', {})
+
         Supplejack::UserSet.find('123abc')
       end
 
       it 'initializes a UserSet object' do
-        Supplejack::UserSet.should_receive(:new).with(id: '123abc', name: 'Dogs', count: 0).and_return(@set)
+        expect(Supplejack::UserSet).to receive(:new).with(id: '123abc', name: 'Dogs', count: 0).and_return(@set)
+
         set = Supplejack::UserSet.find('123abc')
-        set.class.should eq Supplejack::UserSet
+
+        expect(set.class).to eq Supplejack::UserSet
       end
 
       it 'initializes the UserSet and sets the user api_key' do
         set = Supplejack::UserSet.find('123abc', '98765')
-        set.api_key.should eq '98765'
+
+        expect(set.api_key).to eq '98765'
       end
 
       it 'raises a Supplejack::SetNotFound' do
-        Supplejack::UserSet.stub(:get).and_raise(RestClient::ResourceNotFound)
+        allow(Supplejack::UserSet).to receive(:get).and_raise(RestClient::ResourceNotFound)
+
         expect { Supplejack::UserSet.find('123') }.to raise_error(Supplejack::SetNotFound)
       end
     end
 
     describe '#public_sets' do
       before :each do
-        Supplejack::UserSet.stub(:get) { { 'sets' => [{ 'id' => '123', 'name' => 'Dog' }] } }
+        allow(Supplejack::UserSet).to receive(:get) { { 'sets' => [{ 'id' => '123', 'name' => 'Dog' }] } }
       end
 
       it 'fetches the public sets from the api' do
-        Supplejack::UserSet.should_receive(:get).with('/sets/public', page: 1, per_page: 100)
+        expect(Supplejack::UserSet).to receive(:get).with('/sets/public', page: 1, per_page: 100)
+
         Supplejack::UserSet.public_sets
       end
 
       it 'returns an array of user set objects' do
         @set = supplejack_set
-        Supplejack::UserSet.should_receive(:new).once.with('id' => '123', 'name' => 'Dog') { @set }
+        expect(Supplejack::UserSet).to receive(:new).once.with('id' => '123', 'name' => 'Dog') { @set }
+
         sets = Supplejack::UserSet.public_sets
-        sets.should be_a Array
-        sets.size.should eq 1
+
+        expect(sets).to be_a Array
+        expect(sets.size).to eq 1
       end
 
       it 'sends pagination information' do
-        Supplejack::UserSet.should_receive(:get).with('/sets/public', page: 2, per_page: 100)
+        expect(Supplejack::UserSet).to receive(:get).with('/sets/public', page: 2, per_page: 100)
+
         Supplejack::UserSet.public_sets(page: 2)
       end
     end
 
     describe '#featured_sets' do
       before :each do
-        Supplejack::UserSet.stub(:get) { { 'sets' => [{ 'id' => '123', 'name' => 'Dog' }] } }
+        allow(Supplejack::UserSet).to receive(:get) { { 'sets' => [{ 'id' => '123', 'name' => 'Dog' }] } }
       end
 
       it 'fetches the public sets from the api' do
-        Supplejack::UserSet.should_receive(:get).with('/sets/featured')
+        expect(Supplejack::UserSet).to receive(:get).with('/sets/featured')
+
         Supplejack::UserSet.featured_sets
       end
 
       it 'returns an array of user set objects' do
         @set = supplejack_set
-        Supplejack::UserSet.should_receive(:new).once.with('id' => '123', 'name' => 'Dog') { @set }
+
+        expect(Supplejack::UserSet).to receive(:new).once.with('id' => '123', 'name' => 'Dog') { @set }
         sets = Supplejack::UserSet.featured_sets
-        sets.should be_a Array
-        sets.size.should eq 1
+
+        expect(sets).to be_a Array
+        expect(sets.size).to eq 1
       end
     end
   end

--- a/spec/supplejack/user_set_spec.rb
+++ b/spec/supplejack/user_set_spec.rb
@@ -8,30 +8,30 @@ end
 
 module Supplejack
   describe UserSet do
-    let(:supplejack_set) { Supplejack::UserSet.new(records: [{ record_id: 1, position: 2, title: 'Dogs' }]) }
+    let(:supplejack_set) { described_class.new(records: [{ record_id: 1, position: 2, title: 'Dogs' }]) }
 
     before do
-      allow(Supplejack).to receive(:enable_caching) { false }
-      allow(Supplejack::UserSet).to receive(:get) { { 'set' => { id: '123abc', name: 'Dogs', count: 0 } } }
+      allow(Supplejack).to receive(:enable_caching).and_return(false)
+      allow(described_class).to receive(:get).and_return({ 'set' => { id: '123abc', name: 'Dogs', count: 0 } })
     end
 
     describe '#initialize' do
       %i[id name description privacy url priority count tag_list featured approved].each do |attribute|
         it "initializes the #{attribute}" do
-          expect(Supplejack::UserSet.new(attribute => 'value').send(attribute)).to eq 'value'
+          expect(described_class.new(attribute => 'value').send(attribute)).to eq 'value'
         end
       end
 
       it 'converts the updated_at into a time object' do
-        expect(Supplejack::UserSet.new(updated_at: '2012-08-17T10:01:00+12:00').updated_at).to be_a Time
+        expect(described_class.new(updated_at: '2012-08-17T10:01:00+12:00').updated_at).to be_a Time
       end
 
       it 'symbolizes the attributes hash' do
-        expect(Supplejack::UserSet.new('name' => 'Dog').name).to eq 'Dog'
+        expect(described_class.new('name' => 'Dog').name).to eq 'Dog'
       end
 
       it 'initializes a user object' do
-        user_set = Supplejack::UserSet.new(user: { name: 'Juanito' })
+        user_set = described_class.new(user: { name: 'Juanito' })
 
         expect(user_set.user).to be_a Supplejack::User
         expect(user_set.user.name).to eq 'Juanito'
@@ -40,7 +40,7 @@ module Supplejack
 
     describe '#attributes' do
       it 'returns a hash of the set attributes' do
-        set = Supplejack::UserSet.new
+        set = described_class.new
         set.name = 'Dogs'
         set.description = 'Hi'
 
@@ -48,7 +48,7 @@ module Supplejack
       end
 
       it 'includes an array of :records' do
-        set = Supplejack::UserSet.new
+        set = described_class.new
         set.records = [{ record_id: 1, position: 1 }]
 
         expect(set.attributes[:records]).to eq [{ record_id: 1, position: 1 }]
@@ -65,14 +65,14 @@ module Supplejack
         supplejack_set.api_attributes
       end
 
-      it 'should send the featured value' do
+      it 'sends the featured value' do
         supplejack_set.featured = true
 
         expect(supplejack_set.api_attributes).to include(featured: true)
       end
 
       it 'returns a array of records with only id and position' do
-        allow(supplejack_set).to receive(:api_records) { [{ record_id: 1, position: 1 }] }
+        allow(supplejack_set).to receive(:api_records).and_return([{ record_id: 1, position: 1 }])
 
         expect(supplejack_set.api_attributes[:records]).to eq [{ record_id: 1, position: 1 }]
       end
@@ -86,62 +86,62 @@ module Supplejack
 
     describe '#tag_list' do
       it 'returns a comma sepparated list of tags' do
-        expect(Supplejack::UserSet.new(tags: %w[dog cat]).tag_list).to eq 'dog, cat'
+        expect(described_class.new(tags: %w[dog cat]).tag_list).to eq 'dog, cat'
       end
     end
 
     describe '#priority' do
       it 'defaults to 1 when is null' do
-        expect(Supplejack::UserSet.new.priority).to eq 1
+        expect(described_class.new.priority).to eq 1
       end
 
       it 'keeps the value set' do
-        expect(Supplejack::UserSet.new(priority: 0).priority).to eq 0
+        expect(described_class.new(priority: 0).priority).to eq 0
       end
     end
 
     describe '#favourite?' do
       it 'returns true when the name is Favourites' do
-        expect(Supplejack::UserSet.new(name: 'Favourites').favourite?).to be true
+        expect(described_class.new(name: 'Favourites').favourite?).to be true
       end
 
       it 'returns false when the name is something else' do
-        expect(Supplejack::UserSet.new(name: 'Dogs').favourite?).to be false
+        expect(described_class.new(name: 'Dogs').favourite?).to be false
       end
     end
 
     describe '#private?' do
       it 'returns true when the privacy is private' do
-        expect(Supplejack::UserSet.new(privacy: 'private').private?).to be true
+        expect(described_class.new(privacy: 'private').private?).to be true
       end
 
       it 'returns false when the privacy is something else' do
-        expect(Supplejack::UserSet.new(privacy: 'public').private?).to be false
+        expect(described_class.new(privacy: 'public').private?).to be false
       end
     end
 
     describe '#public?' do
       it 'returns false when the privacy is private' do
-        expect(Supplejack::UserSet.new(privacy: 'private').public?).to be false
+        expect(described_class.new(privacy: 'private').public?).to be false
       end
 
       it 'returns true when the privacy is public' do
-        expect(Supplejack::UserSet.new(privacy: 'public').public?).to be true
+        expect(described_class.new(privacy: 'public').public?).to be true
       end
     end
 
     describe '#hidden?' do
       it 'returns false when the privacy is not hidden' do
-        expect(Supplejack::UserSet.new(privacy: 'public').hidden?).to be false
+        expect(described_class.new(privacy: 'public').hidden?).to be false
       end
 
       it 'returns true when the privacy is hidden' do
-        expect(Supplejack::UserSet.new(privacy: 'hidden').hidden?).to be true
+        expect(described_class.new(privacy: 'hidden').hidden?).to be true
       end
     end
 
     describe '#record?' do
-      let(:supplejack_set) { Supplejack::UserSet.new(records: [{ record_id: 1, position: 2, title: 'Dogs' }]) }
+      let(:supplejack_set) { described_class.new(records: [{ record_id: 1, position: 2, title: 'Dogs' }]) }
 
       it 'returns true when the record is part of the set' do
         expect(supplejack_set.record?(1)).to be true
@@ -154,22 +154,23 @@ module Supplejack
 
     describe '#save' do
       let(:attributes) { { name: 'Dogs', description: 'hi', count: 3 } }
+
       before do
-        allow(supplejack_set).to receive(:api_attributes) { attributes }
-        allow(supplejack_set).to receive(:api_key) { '123abc' }
+        allow(supplejack_set).to receive(:api_attributes).and_return(attributes)
+        allow(supplejack_set).to receive(:api_key).and_return('123abc')
       end
 
-      context 'user_set is a new_record' do
-        before { allow(supplejack_set).to receive(:new_record?) { true } }
+      context 'when user_set is a new_record' do
+        before { allow(supplejack_set).to receive(:new_record?).and_return(true) }
 
         it 'triggers a POST request to /sets.json' do
-          expect(Supplejack::UserSet).to receive(:post).with('/sets', { api_key: '123abc' }, set: attributes) { { 'set' => { 'id' => 'new-id' } } }
+          allow(described_class).to receive(:post).with('/sets', { api_key: '123abc' }, set: attributes).and_return({ 'set' => { 'id' => 'new-id' } })
 
           expect(supplejack_set.save).to be true
         end
 
         it 'stores the id of the user_set' do
-          allow(Supplejack::UserSet).to receive(:post) { { 'set' => { 'id' => 'new-id' } } }
+          allow(described_class).to receive(:post).and_return({ 'set' => { 'id' => 'new-id' } })
 
           supplejack_set.save
 
@@ -177,21 +178,21 @@ module Supplejack
         end
 
         it 'returns false for anything other that a 200 response' do
-          allow(Supplejack::UserSet).to receive(:post).and_raise(RestClient::Forbidden.new)
+          allow(described_class).to receive(:post).and_raise(RestClient::Forbidden.new)
 
           expect(supplejack_set.save).to be false
         end
       end
 
-      context 'user_set is not new' do
+      context 'when user_set is not new' do
         before do
-          allow(supplejack_set).to receive(:new_record?) { false }
+          allow(supplejack_set).to receive(:new_record?).and_return(false)
 
           supplejack_set.id = '123'
         end
 
         it 'triggers a PUT request to /sets/123.json with the user set api_key' do
-          expect(Supplejack::UserSet).to receive(:put).with('/sets/123', { api_key: '123abc' }, set: attributes)
+          expect(described_class).to receive(:put).with('/sets/123', { api_key: '123abc' }, set: attributes)
 
           supplejack_set.save
         end
@@ -219,7 +220,7 @@ module Supplejack
         expect(supplejack_set.name).to eq 'Mac'
       end
 
-      it 'should only update passed attributes' do
+      it 'updates only the attributes passed' do
         supplejack_set.id = '12345'
         supplejack_set.attributes = { name: 'Mac' }
 
@@ -247,7 +248,7 @@ module Supplejack
           expect(supplejack_set.send(attr)).to be nil
         end
 
-        it 'should accept a Time object too' do
+        it 'accepts a Time object too' do
           time = Time.now
           supplejack_set.send("#{attr}=", time)
 
@@ -258,19 +259,19 @@ module Supplejack
 
     describe '#api_records' do
       it 'generates a hash of records with position and record_id' do
-        allow(supplejack_set).to receive(:records) { [{ title: 'Hi', record_id: 1, position: 1 }] }
+        allow(supplejack_set).to receive(:records).and_return([{ title: 'Hi', record_id: 1, position: 1 }])
 
         expect(supplejack_set.api_records).to eq [{ record_id: 1, position: 1 }]
       end
 
       it 'removes records without a record_id' do
-        allow(supplejack_set).to receive(:records) { [{ title: 'Hi', record_id: 1, position: 1 }, { position: 6 }] }
+        allow(supplejack_set).to receive(:records).and_return([{ title: 'Hi', record_id: 1, position: 1 }, { position: 6 }])
 
         expect(supplejack_set.api_records).to eq [{ record_id: 1, position: 1 }]
       end
 
       it 'handles nil records' do
-        allow(supplejack_set).to receive(:records) { nil }
+        allow(supplejack_set).to receive(:records).and_return(nil)
 
         expect(supplejack_set.api_records).to eq []
       end
@@ -284,46 +285,46 @@ module Supplejack
 
     describe '#new_record?' do
       it 'returns true when the user_set doesn\'t have a id' do
-        expect(Supplejack::UserSet.new.new_record?).to be true
+        expect(described_class.new.new_record?).to be true
       end
 
       it 'returns false when the user_set has a id' do
-        expect(Supplejack::UserSet.new(id: '1234abc').new_record?).to be false
+        expect(described_class.new(id: '1234abc').new_record?).to be false
       end
     end
 
     describe '#destroy' do
       before do
-        allow(supplejack_set).to receive(:api_key) { '123abc' }
-        allow(supplejack_set).to receive(:id) { '999' }
+        allow(supplejack_set).to receive(:api_key).and_return('123abc')
+        allow(supplejack_set).to receive(:id).and_return('999')
       end
 
       it 'executes a delete request to the API with the user set api_key' do
-        expect(Supplejack::UserSet).to receive(:delete).with('/sets/999', api_key: '123abc')
+        expect(described_class).to receive(:delete).with('/sets/999', api_key: '123abc')
 
         expect(supplejack_set.destroy).to be true
       end
 
       it 'returns false when the response is not a 200' do
-        allow(Supplejack::UserSet).to receive(:delete).and_raise(RestClient::Forbidden.new)
+        allow(described_class).to receive(:delete).and_raise(RestClient::Forbidden.new)
 
         expect(supplejack_set.destroy).to be false
         expect(supplejack_set.errors).to eq 'Forbidden'
       end
 
       it 'returns false when it is a new user set' do
-        allow(supplejack_set).to receive(:new_record?) { true }
+        allow(supplejack_set).to receive(:new_record?).and_return(true)
 
-        expect(Supplejack::UserSet).not_to receive(:delete)
+        expect(described_class).not_to receive(:delete)
         expect(supplejack_set.destroy).to be false
       end
     end
 
     describe '#reload' do
-      let(:supplejack_set) { Supplejack::UserSet.new(id: '123456') }
+      let(:supplejack_set) { described_class.new(id: '123456') }
 
       before do
-        allow(Supplejack::UserSet).to receive(:get).with('/sets/123456') { { 'set' => { 'id' => 'abc' } } }
+        allow(described_class).to receive(:get).with('/sets/123456').and_return({ 'set' => { 'id' => 'abc' } })
       end
 
       it 'fetches the set from the api and repopulates the set' do
@@ -342,33 +343,33 @@ module Supplejack
 
     describe '#viewable_by?' do
       it 'returns true when the user_set is public' do
-        allow(supplejack_set).to receive(:public?) { true }
+        allow(supplejack_set).to receive(:public?).and_return(true)
 
         expect(supplejack_set.viewable_by?(nil)).to be true
       end
 
       it 'returns true when the user_set is hidden' do
-        allow(supplejack_set).to receive(:hidden?) { true }
+        allow(supplejack_set).to receive(:hidden?).and_return(true)
 
         expect(supplejack_set.viewable_by?(nil)).to be true
       end
 
-      context 'private set' do
-        before { allow(supplejack_set).to receive(:public?) { false } }
+      context 'when set is private' do
+        before { allow(supplejack_set).to receive(:public?).and_return(false) }
 
         it 'returns false when the user is not present' do
           expect(supplejack_set.viewable_by?(nil)).to be false
         end
 
         it 'returns true when the user has the same api_key as the user_set' do
-          user = double(:user, api_key: '12345')
+          user = instance_double(Supplejack::User, api_key: '12345')
           supplejack_set.api_key = '12345'
 
           expect(supplejack_set.viewable_by?(user)).to be true
         end
 
         it 'returns false if both the api_key in the user and the set are nil' do
-          user = double(:user, api_key: nil)
+          user = instance_double(Supplejack::User, api_key: nil)
           supplejack_set.api_key = nil
 
           expect(supplejack_set.viewable_by?(user)).to be false
@@ -377,37 +378,36 @@ module Supplejack
     end
 
     describe '#owned_by?' do
-      let(:user) { double(:user, api_key: '123456') }
+      let(:user) { instance_double(Supplejack::User, api_key: '123456') }
 
       it 'returns true when the users api_key is the same as the set\'s' do
-        allow(supplejack_set).to receive(:api_key) { '123456' }
+        allow(supplejack_set).to receive(:api_key).and_return('123456')
 
         expect(supplejack_set.owned_by?(user)).to be true
       end
 
       it 'returns false when the set and user have different api_keys' do
-        allow(supplejack_set).to receive(:api_key) { '666' }
+        allow(supplejack_set).to receive(:api_key).and_return('666')
 
         expect(supplejack_set.owned_by?(user)).to be false
       end
 
       it 'returns false when both keys are nil' do
-        allow(user).to receive(:api_key) { nil }
-
-        allow(supplejack_set).to receive(:api_key) { nil }
+        allow(user).to receive(:api_key).and_return(nil)
+        allow(supplejack_set).to receive(:api_key).and_return(nil)
 
         expect(supplejack_set.owned_by?(user)).to be false
       end
     end
 
     describe '#set_record_id?' do
-      it 'should return the record_id' do
+      it 'returns the record_id' do
         allow(supplejack_set).to receive(:record).and_return('record_id' => 123)
 
         expect(supplejack_set.set_record_id).to eq 123
       end
 
-      it 'should return nil if the set doesn\'t have a record' do
+      it 'returns nil if the set doesn\'t have a record' do
         expect(supplejack_set.set_record_id).to be nil
       end
     end
@@ -415,83 +415,81 @@ module Supplejack
     describe '#find' do
       before do
         @set = supplejack_set
-        allow(Supplejack::UserSet).to receive(:new) { @set }
+        allow(described_class).to receive(:new) { @set }
       end
 
       it 'fetches the set from the api' do
-        expect(Supplejack::UserSet).to receive(:get).with('/sets/123abc', {})
+        expect(described_class).to receive(:get).with('/sets/123abc', {})
 
-        Supplejack::UserSet.find('123abc')
+        described_class.find('123abc')
       end
 
       it 'initializes a UserSet object' do
-        expect(Supplejack::UserSet).to receive(:new).with(id: '123abc', name: 'Dogs', count: 0).and_return(@set)
+        allow(described_class).to receive(:new).with(id: '123abc', name: 'Dogs', count: 0).and_return(@set)
 
-        set = Supplejack::UserSet.find('123abc')
+        set = described_class.find('123abc')
 
-        expect(set.class).to eq Supplejack::UserSet
+        expect(set.class).to eq described_class
       end
 
       it 'initializes the UserSet and sets the user api_key' do
-        set = Supplejack::UserSet.find('123abc', '98765')
+        set = described_class.find('123abc', '98765')
 
         expect(set.api_key).to eq '98765'
       end
 
       it 'raises a Supplejack::SetNotFound' do
-        allow(Supplejack::UserSet).to receive(:get).and_raise(RestClient::ResourceNotFound)
+        allow(described_class).to receive(:get).and_raise(RestClient::ResourceNotFound)
 
-        expect { Supplejack::UserSet.find('123') }.to raise_error(Supplejack::SetNotFound)
+        expect { described_class.find('123') }.to raise_error(Supplejack::SetNotFound)
       end
     end
 
     describe '#public_sets' do
       before do
-        allow(Supplejack::UserSet).to receive(:get) { { 'sets' => [{ 'id' => '123', 'name' => 'Dog' }] } }
+        allow(described_class).to receive(:get).and_return({ 'sets' => [{ 'id' => '123', 'name' => 'Dog' }] })
       end
 
       it 'fetches the public sets from the api' do
-        expect(Supplejack::UserSet).to receive(:get).with('/sets/public', page: 1, per_page: 100)
+        expect(described_class).to receive(:get).with('/sets/public', page: 1, per_page: 100)
 
-        Supplejack::UserSet.public_sets
+        described_class.public_sets
       end
 
       it 'returns an array of user set objects' do
         set = supplejack_set
-        expect(Supplejack::UserSet).to receive(:new).once.with('id' => '123', 'name' => 'Dog') { set }
+        expect(described_class).to receive(:new).once.with('id' => '123', 'name' => 'Dog') { set }
 
-        sets = Supplejack::UserSet.public_sets
+        sets = described_class.public_sets
 
         expect(sets).to be_a Array
-        expect(sets.size).to eq 1
       end
 
       it 'sends pagination information' do
-        expect(Supplejack::UserSet).to receive(:get).with('/sets/public', page: 2, per_page: 100)
+        expect(described_class).to receive(:get).with('/sets/public', page: 2, per_page: 100)
 
-        Supplejack::UserSet.public_sets(page: 2)
+        described_class.public_sets(page: 2)
       end
     end
 
     describe '#featured_sets' do
       before do
-        allow(Supplejack::UserSet).to receive(:get) { { 'sets' => [{ 'id' => '123', 'name' => 'Dog' }] } }
+        allow(described_class).to receive(:get).and_return({ 'sets' => [{ 'id' => '123', 'name' => 'Dog' }] })
       end
 
       it 'fetches the public sets from the api' do
-        expect(Supplejack::UserSet).to receive(:get).with('/sets/featured')
+        expect(described_class).to receive(:get).with('/sets/featured')
 
-        Supplejack::UserSet.featured_sets
+        described_class.featured_sets
       end
 
       it 'returns an array of user set objects' do
         set = supplejack_set
 
-        expect(Supplejack::UserSet).to receive(:new).once.with('id' => '123', 'name' => 'Dog') { set }
-        sets = Supplejack::UserSet.featured_sets
+        expect(described_class).to receive(:new).once.with('id' => '123', 'name' => 'Dog') { set }
+        sets = described_class.featured_sets
 
         expect(sets).to be_a Array
-        expect(sets.size).to eq 1
       end
     end
   end

--- a/spec/supplejack/user_spec.rb
+++ b/spec/supplejack/user_spec.rb
@@ -35,10 +35,6 @@ module Supplejack
 
     describe '#sets' do
       it 'initializes a Supplejack::UserSetRelation object' do
-        @relation = relation
-
-        expect(Supplejack::UserSetRelation).to receive(:new).with(user) { @relation }
-
         expect(user.sets).to be_a Supplejack::UserSetRelation
       end
     end
@@ -156,20 +152,20 @@ module Supplejack
     end
 
     describe '.create' do
-      before :each do
-        @attributes = { email: 'dev@boost.com', name: 'dev', username: 'developer', encrypted_password: 'weird_string' }
+      let(:attributes) { { email: 'dev@boost.com', name: 'dev', username: 'developer', encrypted_password: 'weird_string' } }
 
+      before do
         allow(Supplejack::User).to receive(:post) { { 'user' => { 'email' => 'dev@boost.com', 'name' => 'dev', 'username' => 'developer', 'api_key' => '123456' } } }
       end
 
       it 'executes a post request' do
-        expect(Supplejack::User).to receive(:post).with('/users', {}, user: @attributes)
+        expect(Supplejack::User).to receive(:post).with('/users', {}, user: attributes)
 
-        Supplejack::User.create(@attributes)
+        Supplejack::User.create(attributes)
       end
 
       it 'returns a Supplejack::User object with the api_key' do
-        user = Supplejack::User.create(@attributes)
+        user = Supplejack::User.create(attributes)
 
         expect(user).to be_a Supplejack::User
         expect(user.api_key).to eq '123456'

--- a/spec/supplejack/user_spec.rb
+++ b/spec/supplejack/user_spec.rb
@@ -7,136 +7,150 @@ module Supplejack
     let(:user) { Supplejack::User.new('id' => 'abc', 'authentication_token' => '12345') }
     let(:relation) { Supplejack::UserSetRelation.new(user) }
 
-    before(:each) do
-      Supplejack::User.stub(:get) { { 'user' => { 'id' => 'abc', 'authentication_token' => '12345' } } }
+    before do
+      allow(Supplejack::User).to receive(:get) { { 'user' => { 'id' => 'abc', 'authentication_token' => '12345' } } }
     end
 
     describe '#initialize' do
       it 'initializes the user attributes' do
-        Supplejack::User.new('authentication_token' => '12345').api_key.should eq '12345'
+        expect(Supplejack::User.new('authentication_token' => '12345').api_key).to eq '12345'
       end
 
       it 'initializes the user name' do
-        Supplejack::User.new('name' => 'Juanito').name.should eq 'Juanito'
+        expect(Supplejack::User.new('name' => 'Juanito').name).to eq 'Juanito'
       end
 
       it 'initializes the sets attributes' do
-        Supplejack::User.new('sets' => [{ name: 'Dogs' }]).sets_attributes.should eq [{ name: 'Dogs' }]
+        expect(Supplejack::User.new('sets' => [{ name: 'Dogs' }]).sets_attributes).to eq [{ name: 'Dogs' }]
       end
 
       it 'initializes the use_own_api attribute' do
-        Supplejack::User.new('use_own_api_key' => true).use_own_api_key.should be_truthy
+        expect(Supplejack::User.new('use_own_api_key' => true).use_own_api_key).to be true
       end
 
       it 'initializes the regenerate_api_key attribute' do
-        Supplejack::User.new('regenerate_api_key' => true).regenerate_api_key.should be_truthy
+        expect(Supplejack::User.new('regenerate_api_key' => true).regenerate_api_key).to be true
       end
     end
 
     describe '#sets' do
       it 'initializes a Supplejack::UserSetRelation object' do
         @relation = relation
-        Supplejack::UserSetRelation.should_receive(:new).with(user) { @relation }
-        user.sets.should be_a Supplejack::UserSetRelation
+
+        expect(Supplejack::UserSetRelation).to receive(:new).with(user) { @relation }
+
+        expect(user.sets).to be_a Supplejack::UserSetRelation
       end
     end
 
     describe '#save' do
       it 'should execute a put request with the user attribtues' do
-        user.stub(:api_attributes) { { username: 'John', email: 'john@boost.co.nz' } }
-        Supplejack::User.should_receive(:put).with('/users/12345', {}, username: 'John', email: 'john@boost.co.nz')
-        user.save.should be_truthy
+        allow(user).to receive(:api_attributes) { { username: 'John', email: 'john@boost.co.nz' } }
+
+        expect(Supplejack::User).to receive(:put).with('/users/12345', {}, username: 'John', email: 'john@boost.co.nz')
+
+        expect(user.save).to be true
       end
 
       context 'regenerate api key' do
-        before(:each) do
-          user.regenerate_api_key = true
-        end
+        before { user.regenerate_api_key = true }
 
         it 'should post a nil authentication_token attribute so it is regenerated' do
-          Supplejack::User.should_receive(:put).with('/users/12345', {}, hash_including(authentication_token: nil))
+          expect(Supplejack::User).to receive(:put).with('/users/12345', {}, hash_including(authentication_token: nil))
+
           user.save
         end
 
         it 'should set the regenerated api_key on the user' do
-          Supplejack::User.stub(:put).and_return('user' => { 'id' => '525f7a2df6941993e2000004', 'name' => nil, 'username' => nil, 'email' => nil, 'api_key' => '71H5yPsxVhDmsjmj1NJW' })
+          expect(Supplejack::User).to receive(:put).and_return('user' => { 'id' => '525f7a2df6941993e2000004', 'name' => nil, 'username' => nil, 'email' => nil, 'api_key' => '71H5yPsxVhDmsjmj1NJW' })
+
           user.save
-          user.instance_variable_get('@api_key').should eq '71H5yPsxVhDmsjmj1NJW'
+
+          expect(user.instance_variable_get('@api_key')).to eq '71H5yPsxVhDmsjmj1NJW'
         end
       end
 
       it 'returns false when a error ocurred' do
-        Supplejack::User.stub(:put).and_raise(RestClient::Forbidden)
-        user.save.should be_falsey
+        expect(Supplejack::User).to receive(:put).and_raise(RestClient::Forbidden)
+
+        expect(user.save).to be false
       end
     end
 
     describe '#destroy' do
       it 'should execute a delete request with the admin key' do
-        Supplejack.stub(:api_key) { 'admin_key' }
-        Supplejack::User.should_receive(:delete).with('/users/abc')
-        user.destroy.should be_truthy
+        allow(Supplejack).to receive(:api_key) { 'admin_key' }
+
+        expect(Supplejack::User).to receive(:delete).with('/users/abc')
+
+        expect(user.destroy).to be true
       end
 
       it 'returns false if there is a exception' do
-        Supplejack::User.stub(:delete).and_raise(RestClient::Forbidden)
-        user.destroy.should be_falsey
+        allow(Supplejack::User).to receive(:delete).and_raise(RestClient::Forbidden)
+
+        expect(user.destroy).to be false
       end
     end
 
     describe '#api_attributes' do
       it 'returns the name, username, email and encrypted_password' do
         user = Supplejack::User.new(name: 'John', username: 'Johnny', email: 'john@boost.co.nz', encrypted_password: 'xyz', api_key: '12345')
-        user.api_attributes.should eq(name: 'John', username: 'Johnny', email: 'john@boost.co.nz', encrypted_password: 'xyz')
+
+        expect(user.api_attributes).to eq(name: 'John', username: 'Johnny', email: 'john@boost.co.nz', encrypted_password: 'xyz')
       end
 
       it 'doesn\'t return the attribute if not present' do
-        user.api_attributes.should_not include(:name)
+        expect(user.api_attributes).not_to include(:name)
       end
 
       context 'regenerate api key' do
         let(:user) { Supplejack::User.new(api_key: '12345', regenerate_api_key: true) }
 
         it 'returns a nil authentication_token' do
-          user.api_attributes.should have_key(:authentication_token)
-          user.api_attributes[:authentication_token].should be_nil
+          expect(user.api_attributes).to have_key(:authentication_token)
+
+          expect(user.api_attributes[:authentication_token]).to be nil
         end
       end
 
       it 'returns the sets_attributes' do
         user = Supplejack::User.new(sets: [{ name: 'Dogs', privacy: 'hidden' }])
-        user.api_attributes[:sets].should eq [{ name: 'Dogs', privacy: 'hidden' }]
+
+        expect(user.api_attributes[:sets]).to eq [{ name: 'Dogs', privacy: 'hidden' }]
       end
     end
 
     describe '#use_own_api_key?' do
       it 'returns false by default' do
-        Supplejack::User.new.use_own_api_key?.should be_falsey
+        expect(Supplejack::User.new.use_own_api_key?).to be false
       end
 
       it 'returns true' do
-        Supplejack::User.new('use_own_api_key' => true).use_own_api_key?.should be_truthy
+        expect(Supplejack::User.new('use_own_api_key' => true).use_own_api_key?).to be true
       end
     end
 
     describe '#regenerate_api_key?' do
       it 'returns false by default' do
-        Supplejack::User.new.regenerate_api_key?.should be_falsey
+        expect(Supplejack::User.new.regenerate_api_key?).to be false
       end
 
       it 'returns true' do
-        Supplejack::User.new('regenerate_api_key' => true).regenerate_api_key?.should be_truthy
+        expect(Supplejack::User.new('regenerate_api_key' => true).regenerate_api_key?).to be true
       end
     end
 
     describe '.find' do
       it 'fetches the user from the api' do
-        Supplejack::User.should_receive(:get).with('/users/12345')
+        expect(Supplejack::User).to receive(:get).with('/users/12345')
+
         Supplejack::User.find('12345')
       end
 
       it 'initializes a user with the response' do
-        Supplejack::User.should_receive(:new).with('id' => 'abc', 'authentication_token' => '12345')
+        expect(Supplejack::User).to receive(:new).with('id' => 'abc', 'authentication_token' => '12345')
+
         Supplejack::User.find('12345')
       end
     end
@@ -144,18 +158,21 @@ module Supplejack
     describe '.create' do
       before :each do
         @attributes = { email: 'dev@boost.com', name: 'dev', username: 'developer', encrypted_password: 'weird_string' }
-        Supplejack::User.stub(:post) { { 'user' => { 'email' => 'dev@boost.com', 'name' => 'dev', 'username' => 'developer', 'api_key' => '123456' } } }
+
+        allow(Supplejack::User).to receive(:post) { { 'user' => { 'email' => 'dev@boost.com', 'name' => 'dev', 'username' => 'developer', 'api_key' => '123456' } } }
       end
 
       it 'executes a post request' do
-        Supplejack::User.should_receive(:post).with('/users', {}, user: @attributes)
+        expect(Supplejack::User).to receive(:post).with('/users', {}, user: @attributes)
+
         Supplejack::User.create(@attributes)
       end
 
       it 'returns a Supplejack::User object with the api_key' do
         user = Supplejack::User.create(@attributes)
-        user.should be_a Supplejack::User
-        user.api_key.should eq '123456'
+
+        expect(user).to be_a Supplejack::User
+        expect(user.api_key).to eq '123456'
       end
     end
   end

--- a/spec/supplejack/user_spec.rb
+++ b/spec/supplejack/user_spec.rb
@@ -4,32 +4,32 @@ require 'spec_helper'
 
 module Supplejack
   describe User do
-    let(:user) { Supplejack::User.new('id' => 'abc', 'authentication_token' => '12345') }
+    let(:user) { described_class.new('id' => 'abc', 'authentication_token' => '12345') }
     let(:relation) { Supplejack::UserSetRelation.new(user) }
 
     before do
-      allow(Supplejack::User).to receive(:get) { { 'user' => { 'id' => 'abc', 'authentication_token' => '12345' } } }
+      allow(described_class).to receive(:get).and_return({ 'user' => { 'id' => 'abc', 'authentication_token' => '12345' } })
     end
 
     describe '#initialize' do
       it 'initializes the user attributes' do
-        expect(Supplejack::User.new('authentication_token' => '12345').api_key).to eq '12345'
+        expect(described_class.new('authentication_token' => '12345').api_key).to eq '12345'
       end
 
       it 'initializes the user name' do
-        expect(Supplejack::User.new('name' => 'Juanito').name).to eq 'Juanito'
+        expect(described_class.new('name' => 'Juanito').name).to eq 'Juanito'
       end
 
       it 'initializes the sets attributes' do
-        expect(Supplejack::User.new('sets' => [{ name: 'Dogs' }]).sets_attributes).to eq [{ name: 'Dogs' }]
+        expect(described_class.new('sets' => [{ name: 'Dogs' }]).sets_attributes).to eq [{ name: 'Dogs' }]
       end
 
       it 'initializes the use_own_api attribute' do
-        expect(Supplejack::User.new('use_own_api_key' => true).use_own_api_key).to be true
+        expect(described_class.new('use_own_api_key' => true).use_own_api_key).to be true
       end
 
       it 'initializes the regenerate_api_key attribute' do
-        expect(Supplejack::User.new('regenerate_api_key' => true).regenerate_api_key).to be true
+        expect(described_class.new('regenerate_api_key' => true).regenerate_api_key).to be true
       end
     end
 
@@ -40,25 +40,25 @@ module Supplejack
     end
 
     describe '#save' do
-      it 'should execute a put request with the user attribtues' do
-        allow(user).to receive(:api_attributes) { { username: 'John', email: 'john@boost.co.nz' } }
+      it 'executes a put request with the user attribtues' do
+        allow(user).to receive(:api_attributes).and_return({ username: 'John', email: 'john@boost.co.nz' })
 
-        expect(Supplejack::User).to receive(:put).with('/users/12345', {}, username: 'John', email: 'john@boost.co.nz')
+        expect(described_class).to receive(:put).with('/users/12345', {}, username: 'John', email: 'john@boost.co.nz')
 
         expect(user.save).to be true
       end
 
-      context 'regenerate api key' do
+      context 'when regenerate_api_key is true' do
         before { user.regenerate_api_key = true }
 
-        it 'should post a nil authentication_token attribute so it is regenerated' do
-          expect(Supplejack::User).to receive(:put).with('/users/12345', {}, hash_including(authentication_token: nil))
+        it 'posts a nil authentication_token attribute so it is regenerated' do
+          expect(described_class).to receive(:put).with('/users/12345', {}, hash_including(authentication_token: nil))
 
           user.save
         end
 
-        it 'should set the regenerated api_key on the user' do
-          expect(Supplejack::User).to receive(:put).and_return('user' => { 'id' => '525f7a2df6941993e2000004', 'name' => nil, 'username' => nil, 'email' => nil, 'api_key' => '71H5yPsxVhDmsjmj1NJW' })
+        it 'sets the regenerated api_key on the user' do
+          allow(described_class).to receive(:put).and_return('user' => { 'id' => '525f7a2df6941993e2000004', 'name' => nil, 'username' => nil, 'email' => nil, 'api_key' => '71H5yPsxVhDmsjmj1NJW' })
 
           user.save
 
@@ -67,23 +67,23 @@ module Supplejack
       end
 
       it 'returns false when a error ocurred' do
-        expect(Supplejack::User).to receive(:put).and_raise(RestClient::Forbidden)
+        allow(described_class).to receive(:put).and_raise(RestClient::Forbidden)
 
         expect(user.save).to be false
       end
     end
 
     describe '#destroy' do
-      it 'should execute a delete request with the admin key' do
-        allow(Supplejack).to receive(:api_key) { 'admin_key' }
+      it 'executes a delete request with the admin key' do
+        allow(Supplejack).to receive(:api_key).and_return('admin_key')
 
-        expect(Supplejack::User).to receive(:delete).with('/users/abc')
+        expect(described_class).to receive(:delete).with('/users/abc')
 
         expect(user.destroy).to be true
       end
 
       it 'returns false if there is a exception' do
-        allow(Supplejack::User).to receive(:delete).and_raise(RestClient::Forbidden)
+        allow(described_class).to receive(:delete).and_raise(RestClient::Forbidden)
 
         expect(user.destroy).to be false
       end
@@ -91,7 +91,7 @@ module Supplejack
 
     describe '#api_attributes' do
       it 'returns the name, username, email and encrypted_password' do
-        user = Supplejack::User.new(name: 'John', username: 'Johnny', email: 'john@boost.co.nz', encrypted_password: 'xyz', api_key: '12345')
+        user = described_class.new(name: 'John', username: 'Johnny', email: 'john@boost.co.nz', encrypted_password: 'xyz', api_key: '12345')
 
         expect(user.api_attributes).to eq(name: 'John', username: 'Johnny', email: 'john@boost.co.nz', encrypted_password: 'xyz')
       end
@@ -100,8 +100,8 @@ module Supplejack
         expect(user.api_attributes).not_to include(:name)
       end
 
-      context 'regenerate api key' do
-        let(:user) { Supplejack::User.new(api_key: '12345', regenerate_api_key: true) }
+      context 'when regenerate_api_key is true' do
+        let(:user) { described_class.new(api_key: '12345', regenerate_api_key: true) }
 
         it 'returns a nil authentication_token' do
           expect(user.api_attributes).to have_key(:authentication_token)
@@ -111,7 +111,7 @@ module Supplejack
       end
 
       it 'returns the sets_attributes' do
-        user = Supplejack::User.new(sets: [{ name: 'Dogs', privacy: 'hidden' }])
+        user = described_class.new(sets: [{ name: 'Dogs', privacy: 'hidden' }])
 
         expect(user.api_attributes[:sets]).to eq [{ name: 'Dogs', privacy: 'hidden' }]
       end
@@ -119,35 +119,35 @@ module Supplejack
 
     describe '#use_own_api_key?' do
       it 'returns false by default' do
-        expect(Supplejack::User.new.use_own_api_key?).to be false
+        expect(described_class.new.use_own_api_key?).to be false
       end
 
       it 'returns true' do
-        expect(Supplejack::User.new('use_own_api_key' => true).use_own_api_key?).to be true
+        expect(described_class.new('use_own_api_key' => true).use_own_api_key?).to be true
       end
     end
 
     describe '#regenerate_api_key?' do
       it 'returns false by default' do
-        expect(Supplejack::User.new.regenerate_api_key?).to be false
+        expect(described_class.new.regenerate_api_key?).to be false
       end
 
       it 'returns true' do
-        expect(Supplejack::User.new('regenerate_api_key' => true).regenerate_api_key?).to be true
+        expect(described_class.new('regenerate_api_key' => true).regenerate_api_key?).to be true
       end
     end
 
     describe '.find' do
       it 'fetches the user from the api' do
-        expect(Supplejack::User).to receive(:get).with('/users/12345')
+        expect(described_class).to receive(:get).with('/users/12345')
 
-        Supplejack::User.find('12345')
+        described_class.find('12345')
       end
 
       it 'initializes a user with the response' do
-        expect(Supplejack::User).to receive(:new).with('id' => 'abc', 'authentication_token' => '12345')
+        expect(described_class).to receive(:new).with('id' => 'abc', 'authentication_token' => '12345')
 
-        Supplejack::User.find('12345')
+        described_class.find('12345')
       end
     end
 
@@ -155,19 +155,19 @@ module Supplejack
       let(:attributes) { { email: 'dev@boost.com', name: 'dev', username: 'developer', encrypted_password: 'weird_string' } }
 
       before do
-        allow(Supplejack::User).to receive(:post) { { 'user' => { 'email' => 'dev@boost.com', 'name' => 'dev', 'username' => 'developer', 'api_key' => '123456' } } }
+        allow(described_class).to receive(:post).and_return({ 'user' => { 'email' => 'dev@boost.com', 'name' => 'dev', 'username' => 'developer', 'api_key' => '123456' } })
       end
 
       it 'executes a post request' do
-        expect(Supplejack::User).to receive(:post).with('/users', {}, user: attributes)
+        expect(described_class).to receive(:post).with('/users', {}, user: attributes)
 
-        Supplejack::User.create(attributes)
+        described_class.create(attributes)
       end
 
       it 'returns a Supplejack::User object with the api_key' do
-        user = Supplejack::User.create(attributes)
+        user = described_class.create(attributes)
 
-        expect(user).to be_a Supplejack::User
+        expect(user).to be_a described_class
         expect(user.api_key).to eq '123456'
       end
     end

--- a/spec/supplejack/user_story_relation_spec.rb
+++ b/spec/supplejack/user_story_relation_spec.rb
@@ -9,7 +9,7 @@ module Supplejack
     let(:relation) { Supplejack::UserStoryRelation.new(user) }
 
     before do
-      relation.stub(:get) do
+      allow(relation).to receive(:get).and_return(
         [
           {
             'id' => '1',
@@ -30,7 +30,7 @@ module Supplejack
             'number_of_items' => 1
           }
         ]
-      end
+      )
     end
 
     describe '#initialize' do
@@ -124,13 +124,11 @@ module Supplejack
 
     describe '#order' do
       before do
-        relation.stub(:get) do
-          [
-            { 'name' => 'dogs' },
-            { 'name' => 'zavourites' },
-            { 'name' => 'Favourites' }
-          ]
-        end
+        allow(relation).to receive(:get).and_return(
+          [{ 'name' => 'dogs' },
+           { 'name' => 'zavourites' },
+           { 'name' => 'Favourites' }]
+        )
       end
 
       it 'orders the stories based on the supplied field' do
@@ -150,7 +148,7 @@ module Supplejack
 
     context 'stories array behaviour' do
       it 'executes array methods on the @stories array' do
-        relation.stub(:all) { [] }
+        allow(relation).to receive(:all) { [] }
 
         expect(relation.size).to eq(0)
       end

--- a/spec/supplejack/user_story_relation_spec.rb
+++ b/spec/supplejack/user_story_relation_spec.rb
@@ -2,11 +2,10 @@
 
 require 'spec_helper'
 
-# rubocop:disable Lint/AmbiguousBlockAssociation
 module Supplejack
   describe UserStoryRelation do
     let(:user) { Supplejack::User.new(authentication_token: '123abc') }
-    let(:relation) { Supplejack::UserStoryRelation.new(user) }
+    let(:relation) { described_class.new(user) }
 
     before do
       allow(relation).to receive(:get).and_return(
@@ -35,7 +34,7 @@ module Supplejack
 
     describe '#initialize' do
       it 'initializes with a UserSet object' do
-        expect(Supplejack::UserStoryRelation.new(user).user).to eq(user)
+        expect(described_class.new(user).user).to eq(user)
       end
     end
 
@@ -48,7 +47,7 @@ module Supplejack
     end
 
     describe '#fetch' do
-      context 'use_own_api_key? is false' do
+      context 'when use_own_api_key is false' do
         it 'fetches the users stories with the App api_key' do
           expect(relation).to receive(:get).with('/users/123abc/stories', {})
 
@@ -56,7 +55,7 @@ module Supplejack
         end
       end
 
-      context 'use_own_api_key? is true' do
+      context 'when use_own_api_key is true' do
         let(:user) { Supplejack::User.new(api_key: '123abc', use_own_api_key: true) }
 
         it 'fetches the users stories with their api_key' do
@@ -69,20 +68,18 @@ module Supplejack
       it 'returns a array of Story objects' do
         expect(relation.fetch).to be_a Array
 
-        relation.fetch.each do |story|
-          expect(story).to be_a Supplejack::Story
-        end
+        expect(relation).to all(be_a Supplejack::Story)
       end
 
       it 'memoizes the result' do
-        expect(relation).to receive(:fetch_api_stories).once { [] }
+        expect(relation).to receive(:fetch_api_stories).once.and_return([])
 
         relation.fetch
         relation.fetch
       end
 
       it 'lets you force a refetch' do
-        expect(relation).to receive(:fetch_api_stories).twice { [] }
+        expect(relation).to receive(:fetch_api_stories).twice.and_return([])
 
         relation.fetch
         relation.fetch(force: true)
@@ -108,9 +105,8 @@ module Supplejack
     describe '#create' do
       it 'initializes the Story and saves it' do
         story = relation.build(name: 'Dogs')
-        allow(relation).to receive(:build).with(name: 'Dogs') { story }
-
-        expect(story).to receive(:save) { true }
+        allow(relation).to receive(:build).with(name: 'Dogs').and_return(story)
+        allow(story).to receive(:save).and_return(true)
 
         expect(relation.create(name: 'Dogs')).to be_a Supplejack::Story
       end
@@ -134,25 +130,22 @@ module Supplejack
       it 'orders the stories based on the supplied field' do
         ordered_relations = relation.order(:name)
 
-        expect(ordered_relations[0].name).to eq('dogs')
-        expect(ordered_relations[1].name).to eq('Favourites')
-        expect(ordered_relations[2].name).to eq('zavourites')
+        expect(ordered_relations.map(&:name)).to eq %w[dogs Favourites zavourites]
       end
     end
 
     describe '#all' do
-      it 'it is an alias to #fetch' do
+      it 'is an alias to #fetch' do
         expect(relation.all).to eq(relation.fetch)
       end
     end
 
-    context 'stories array behaviour' do
+    context 'when stories array behaviour' do
       it 'executes array methods on the @stories array' do
-        allow(relation).to receive(:all) { [] }
+        allow(relation).to receive(:all).and_return([])
 
         expect(relation.size).to eq(0)
       end
     end
   end
 end
-# rubocop:enable Lint/AmbiguousBlockAssociation


### PR DESCRIPTION
**Acceptance Criteria**
- When enabling `config.raise_errors_for_deprecations!` in RSpec config all specs should pass

**Changes**
- Old RSpec syntax updated
- rspec-rubocop enabled