### PR TITLE
FIX REDUNDANT PARAMS IN STORIES API CALL

### DIFF
--- a/lib/supplejack/story_item.rb
+++ b/lib/supplejack/story_item.rb
@@ -66,13 +66,13 @@ module Supplejack
                           post(
                             "/stories/#{story_id}/items",
                             { user_key: api_key },
-                            item: api_attributes
+                            story_item: api_attributes
                           )
                         else
                           patch(
                             "/stories/#{story_id}/items/#{id}",
                             { user_key: api_key },
-                            item: api_attributes
+                            story_item: api_attributes
                           )
                         end
 

--- a/spec/supplejack/story_item_spec.rb
+++ b/spec/supplejack/story_item_spec.rb
@@ -29,7 +29,7 @@ module Supplejack
 
       context 'when item is new ' do
         it 'triggers a POST request to create a story_item with the story api_key' do
-          expect(item).to receive(:post).with('/stories/1234/items', { user_key: 'abc' }, item: { meta: {}, type: 'embed', sub_type: 'supplejack_user' })
+          expect(item).to receive(:post).with('/stories/1234/items', { user_key: 'abc' }, story_item: { meta: {}, type: 'embed', sub_type: 'supplejack_user' })
 
           expect(item.save).to eq(true)
         end
@@ -38,7 +38,7 @@ module Supplejack
       context 'with existing item' do
         it 'triggers a PATCH request to update a story_item with the story api_key' do
           item.id = 1
-          expect(item).to receive(:patch).with('/stories/1234/items/1', { user_key: 'abc' }, item: { meta: {}, type: 'embed', sub_type: 'supplejack_user' })
+          expect(item).to receive(:patch).with('/stories/1234/items/1', { user_key: 'abc' }, story_item: { meta: {}, type: 'embed', sub_type: 'supplejack_user' })
 
           expect(item.save).to eq(true)
         end


### PR DESCRIPTION
**Acceptance Criteria**
Unwanted params are removed from the call.

**Issue**
When the controller name is not used to wrap the params that are send on a post/put method ParamsWrapper makes a copy of the params and adds them to params with a new key named after the controller name. This clutters the logs as the params are doubled.

**Fix**
Fix is to follow Rails convention and used the same name as the controller for params. Its updated in `supplejack_api`. Client is updated for this change.