### PR TITLE
NEXT/PREVIOUS ON SJ API: As a user, I would like to be able to click through to the next page of results, so that I can keep looking at things I've found on natlib.govt.nz.

### DIFF
--- a/lib/supplejack/controllers/helpers.rb
+++ b/lib/supplejack/controllers/helpers.rb
@@ -135,10 +135,9 @@ module Supplejack
         previous_label = previous_label.html_safe
 
         if record.previous_record
-          options[:page] = record.previous_page if record.previous_page.to_i > 1
-          path = record_path(record.previous_record, search: options)
-          path = path.split('?')[0] if path.include?('?') && html_options[:include_querystring]
-          path = "#{path}?#{request.query_string}" if html_options[:include_querystring]
+          options = html_options[:include_querystring] ? request.query_parameters : { search: {} }
+          options[:search][:page] = record.previous_page
+          path = record_path(record.previous_record, options)
           links += link_to(raw(previous_label), path, class: html_options[:prev_class]).html_safe
         else
           links += content_tag(:span, previous_label, class: html_options[:prev_class])
@@ -151,10 +150,9 @@ module Supplejack
         next_label = next_label.html_safe
 
         if record.next_record
-          options[:page] = record.next_page if record.next_page.to_i > 1
-          path = record_path(record.next_record, search: options)
-          path = path.split('?')[0] if path.include?('?') && html_options[:include_querystring]
-          path = "#{path}?#{request.query_string}" if html_options[:include_querystring]
+          options = html_options[:include_querystring] ? request.query_parameters : { search: {} }
+          options[:search][:page] = record.next_page if record.next_page.to_i > 1
+          path = record_path(record.next_record, options)
           links += link_to(raw(next_label), path, class: html_options[:next_class]).html_safe
         else
           links += content_tag(:span, next_label, class: html_options[:next_class])


### PR DESCRIPTION
[NEXT/PREVIOUS ON SJ API: As a user, I would like to be able to click through to the next page of results, so that I can keep looking at things I've found on natlib.govt.nz.](https://www.pivotaltracker.com/story/show/184020589)

STORY
=====

**Acceptance criteria** 
- SJ API can facilitate next & previous queries
- Documentation reflects new functionality
- SJ Client is updated

**Notes**
This feature seems a bit out of place

- the code looks a bit old and complicated
- only natlib uses it at the moment
- natlib pagination is not working, clicking `next` in the last record of a result page doesn't go to the next page.
- should we remove this feature? How to do this gracefully without impacting natlib?
