### PR TITLE
FIX LAST RELEASE FOR < RAILS 7.1

### DIFF
--- a/lib/supplejack/version.rb
+++ b/lib/supplejack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Supplejack
-  VERSION = '2.3.11'
+  VERSION = '2.3.13'
 end

--- a/supplejack_client.gemspec
+++ b/supplejack_client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths         = ['lib']
   spec.version               = Supplejack::VERSION
 
-  spec.add_dependency 'rails', '>= 7.1'
+  spec.add_dependency 'rails', '>= 7.1.0'
   spec.add_dependency 'rails_autolink', '~> 1.0'
   spec.add_dependency 'rest-client', '~> 2.0'
 

--- a/supplejack_client.gemspec
+++ b/supplejack_client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths         = ['lib']
   spec.version               = Supplejack::VERSION
 
-  spec.add_dependency 'rails', '>= 6.1.4'
+  spec.add_dependency 'rails', '>= 7.1'
   spec.add_dependency 'rails_autolink', '~> 1.0'
   spec.add_dependency 'rest-client', '~> 2.0'
 


### PR DESCRIPTION
fix: the latest MODES updates requires rails 7.1 and breaks without it.

Question: is this a good idea to expect Rails 7.1? If not, we might want to revert the changes in the last release instead.