### PR TITLE
FIX DEPRECATION WARNING AND ADD RAILS 7.1 DEPENDENCY

### DIFF
--- a/lib/supplejack/log_subscriber.rb
+++ b/lib/supplejack/log_subscriber.rb
@@ -12,9 +12,9 @@ module Supplejack
 
       name = format('%s (%.1fms)', "Supplejack API #{Rails.env}", duration)
 
-      parameters = payload[:params].map { |k, v| "#{k}: #{colorize(v, BOLD)}" }.join(', ')
-      body = payload[:payload].map { |k, v| "#{k}: #{colorize(v, BOLD)}" }.join(', ')
-      options = payload[:options].map { |k, v| "#{k}: #{colorize(v, BOLD)}" }.join(', ')
+      parameters = payload[:params].map { |k, v| "#{k}: #{colorize(v, MODES[:bold])}" }.join(', ')
+      body = payload[:payload].map { |k, v| "#{k}: #{colorize(v, MODES[:bold])}" }.join(', ')
+      options = payload[:options].map { |k, v| "#{k}: #{colorize(v, MODES[:bold])}" }.join(', ')
       request = "#{method.to_s.upcase} path=#{payload[:path]} params={#{parameters}}, body={#{body}} options={#{options}}"
 
       if payload[:exception]
@@ -22,7 +22,7 @@ module Supplejack
       else
         info = ''
         if solr_request_params.try(:any?)
-          solr_request_params = solr_request_params.map { |k, v| "#{k}: #{colorize(v, BOLD)}" }.join(', ')
+          solr_request_params = solr_request_params.map { |k, v| "#{k}: #{colorize(v, MODES[:bold])}" }.join(', ')
           info = "\n  #{colorize('SOLR Request', YELLOW)} [ #{solr_request_params} ]"
         end
       end
@@ -35,7 +35,7 @@ module Supplejack
       when Array then "[#{text.map { |e| colorize(e, color) }.join(', ')}]"
       when Hash then "{#{text.map { |k, v| "#{k}: #{colorize(v, color)}" }.join(', ')}}"
       else
-        "#{BOLD}#{color}#{text}#{CLEAR}"
+        "#{MODES[:bold]}#{color}#{text}#{MODES[:clear]}"
       end
     end
   end

--- a/lib/supplejack/version.rb
+++ b/lib/supplejack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Supplejack
-  VERSION = '2.3.13'
+  VERSION = '3.0.0'
 end

--- a/supplejack_client.gemspec
+++ b/supplejack_client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths         = ['lib']
   spec.version               = Supplejack::VERSION
 
-  spec.add_dependency 'rails', '>= 6.1.4'
+  spec.add_dependency 'rails', '>= 7.1.0'
   spec.add_dependency 'rails_autolink', '~> 1.0'
   spec.add_dependency 'rest-client', '~> 2.0'
 


### PR DESCRIPTION
- Re-apply commit `95ff7c5a57ab1b657d18701959eb05427e688255` which fixes deprecation warnings
- Add dependency for Rails 7.1.0 as the deprecation fix requires this dependency
- Bump the version to `3.0.0` as a major version dependency is required for gem